### PR TITLE
Bugfix/gh17 fix permissions yorc key

### DIFF
--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -44,10 +44,6 @@ topology_template:
       type: string
       required: true
       description: "The OpenStack user name to use."
-    os_key_pair_content:
-      type: string
-      required: true
-      description: "Content of the key pair used to connect on the OpenStack computes. Stored as ~/.ssh/yorc.pem"
     os_default_security_groups:
       type: list
       entry_schema:
@@ -60,6 +56,10 @@ topology_template:
     os_private_network_name:
       type: string
       description: "The name of private network to use as primary adminstration network between Yorc and Compute instances. It should be a private network accessible by this instance of Yorc."
+    private_key_content:
+      type: string
+      required: true
+      description: "Content of the default ssh private key used to connect on computes. Stored as ~/.ssh/yorc.pem"
   node_templates:
     OracleJDK:
       type: org.alien4cloud.java.jdk.linux.nodes.OracleJDK
@@ -160,6 +160,7 @@ topology_template:
         install_dir: "/usr/local/bin"
         config_dir: "/etc/yorc"
         data_dir: "/var/yorc"
+        private_key_content: { get_input: private_key_content }
       requirements:
       - hostedOnComputeHost:
           type_requirement: host
@@ -260,7 +261,6 @@ topology_template:
         password: { get_input: os_password }
         private_network_name: { get_input: os_private_network_name }
         default_security_groups: { get_input: os_default_security_groups }
-        key_pair: { get_input: os_key_pair_content }
 
       requirements:
       - yorcConfigOpenstackHostedOnYorcYorcServerConfig:

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -53,10 +53,6 @@ topology_template:
       type: string
       required: true
       description: "The OpenStack user name to use."
-    os_key_pair_content:
-      type: string
-      required: true
-      description: "Content of the key pair used to connect on the OpenStack computes. Stored as ~/.ssh/yorc.pem"
     os_auth_url:
       type: string
       required: true
@@ -86,6 +82,10 @@ topology_template:
       type: string
       required: true
       description: "The TLS client key used for authentication"
+    private_key_content:
+      type: string
+      required: true
+      description: "Content of the default ssh private key used to connect on computes. Stored as ~/.ssh/yorc.pem"
 
   node_templates:
     ComputeAlien:
@@ -300,7 +300,6 @@ topology_template:
         user_name: { get_input: os_user_name }
         password: { get_input: os_password }
         private_network_name: { get_input: os_private_network_name }
-        key_pair: { get_input: os_key_pair_content }
 
       requirements:
       - yorcConfigOpenstackHostedOnYorcYorcServerConfig:
@@ -405,6 +404,7 @@ topology_template:
         install_dir: "/usr/local/bin"
         config_dir: "/etc/yorc"
         data_dir: "/var/yorc"
+        private_key_content: { get_input: private_key_content }
       requirements:
       - hostedOnComputeYorcHost:
           type_requirement: host

--- a/org/ystia/yorc/README.rst
+++ b/org/ystia/yorc/README.rst
@@ -34,6 +34,8 @@ Properties
 
   - Default : /var/yorc
 
+- **private_key_content** : The content of the default ssh private key pair to use to connect on computes. It will be stored as `~/.ssh/yorc.pem`.
+
 Requirements
 ^^^^^^^^^^^^
 
@@ -73,8 +75,6 @@ Properties
 - **private_network_name** : The name of private network to use as primary adminstration network between Yorc and Compute instances. It should be a private network accessible by this instance of Yorc.
 
 - **default_security_groups** : Default security groups to be used when creating a Compute instance.
-
-- **key_pair** : The Key pair to use to connect on the OpenStack computes.
 
 
 Requirements

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure.yml
@@ -46,3 +46,14 @@
       file:
         path: /tmp/yorc.d/
         state: absent
+
+    - name: "Ensures {{ DATA_DIR }}/.ssh dir exists"
+      file:
+        path: "{{ DATA_DIR }}/.ssh"
+        state: directory
+
+    - name: "Copy key pair"
+      copy:
+        content: "{{ SSH_KEY }}"
+        dest: "{{ DATA_DIR }}/.ssh/yorc.pem"
+        mode: 0400

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure.yml
@@ -51,9 +51,13 @@
       file:
         path: "{{ DATA_DIR }}/.ssh"
         state: directory
+        owner: yorc
+        group: yorc
 
     - name: "Copy key pair"
       copy:
         content: "{{ SSH_KEY }}"
         dest: "{{ DATA_DIR }}/.ssh/yorc.pem"
+        owner: yorc
+        group: yorc
         mode: 0400

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_openstack.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_openstack.yml
@@ -54,14 +54,3 @@
       copy:
         content: "{{ yorcConfig | to_yaml }}"
         dest: "{{ CONFIG_DIR }}/config.yorc.yaml"
-
-    - name: "Ensures {{ DATA_DIR }}/.ssh dir exists"
-      file:
-        path: "{{ DATA_DIR }}/.ssh"
-        state: directory
-
-    - name: "Copy key pair"
-      copy:
-        content: "{{ KEY_PAIR }}"
-        dest: "{{ DATA_DIR }}/.ssh/yorc.pem"
-        mode: 0400

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_openstack.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_openstack.yml
@@ -64,3 +64,4 @@
       copy:
         content: "{{ KEY_PAIR }}"
         dest: "{{ DATA_DIR }}/.ssh/yorc.pem"
+        mode: 0400

--- a/org/ystia/yorc/yorc/linux/ansible/types.yaml
+++ b/org/ystia/yorc/yorc/linux/ansible/types.yaml
@@ -71,6 +71,7 @@ node_types:
         configure:
           inputs:
             REST_API_PORT: { get_property: [SELF, rest, port] }
+            SSH_KEY: { get_property: [SELF, private_key_content] }
           implementation: playbooks/configure.yml
         start: playbooks/start.yml
         stop: playbooks/stop.yml
@@ -140,7 +141,6 @@ relationship_types:
             PASSWORD: { get_property: [SOURCE, password] }
             PRIVATE_NETWORK_NAME: { get_property: [SOURCE, private_network_name] }
             DEFAULT_SECURITY_GROUPS: { get_property: [SOURCE, default_security_groups] }
-            KEY_PAIR: { get_property: [SOURCE, key_pair] }
           implementation: playbooks/configure_openstack.yml
 
   org.ystia.yorc.linux.ansible.relationships.YorcConfigKubernetesHostedOnYorc:

--- a/org/ystia/yorc/yorc/pub/types.yaml
+++ b/org/ystia/yorc/yorc/pub/types.yaml
@@ -58,9 +58,6 @@ node_types:
         required: false
         entry_schema:
           type: string
-      key_pair:
-        description: "Content of the key pair used to connect on the OpenStack computes. Stored as ~/.ssh/yorc.pem"
-        type: string
     requirements:
     - host:
         capability: org.ystia.yorc.pub.capabilities.YorcConfigContainer
@@ -146,6 +143,9 @@ node_types:
         type: string
         required: true
         default: /var/yorc
+      private_key_content:
+        description: "Content of the default ssh private key used to connect on computes. Stored as ~/.ssh/yorc.pem"
+        type: string
     requirements:
     - consul:
         capability: org.alien4cloud.consul.pub.capabilities.ConsulAgent


### PR DESCRIPTION
Fixes #17

Move ssh private key property (yorc.pem) from Openstack config to Yorc's component.
Renamed from key_pair to private_key_content to make this consistent.
Updated topologies. 

And fix permissions on yorc.pem