### PR TITLE
Feature/alien4cloud 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### DEPENDENCIES
 
 * Ystia Forge components require now Alien4Cloud 2.1.0-SM6
+* Ystia Forge components require now Alien4Cloud CSAR public library 2.1.0-SM6
 
 ### IMPROVEMENTS
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,6 @@
 
 * Ystia Forge components require now Alien4Cloud 2.1.0-SM6
 
+### IMPROVEMENTS
+
+* Ystia Forge Consul components at org/ystia/experimental/consul/ install now Consul 1.2.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Ystia Forge Changelog
+
+## UNRELEASED
+
+### DEPENDENCIES
+
+* Ystia Forge components require now Alien4Cloud 2.1.0-SM6
+

--- a/org/ystia/experimental/consul/pub/types.yaml
+++ b/org/ystia/experimental/consul/pub/types.yaml
@@ -58,7 +58,7 @@ node_types:
       download_url:
         description: The URL to download the consul archive.
         # override default version of supported consul
-        default: https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip
+        default: https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip
         type: string
         required: true
       install_dir:

--- a/org/ystia/experimental/consul/pub/types.yaml
+++ b/org/ystia/experimental/consul/pub/types.yaml
@@ -23,7 +23,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  -  org.alien4cloud.consul.pub:2.0.0
+  - org.alien4cloud.consul.pub:2.1.0-SNAPSHOT
 
 description: >
   This component exposes public interfaces for Consul

--- a/org/ystia/experimental/consul/pub/types.yaml
+++ b/org/ystia/experimental/consul/pub/types.yaml
@@ -23,7 +23,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.alien4cloud.consul.pub:2.1.0-SNAPSHOT
+  - org.alien4cloud.consul.pub:2.1.0-SM6
 
 description: >
   This component exposes public interfaces for Consul

--- a/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
+++ b/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
@@ -25,7 +25,7 @@ description: "This topology illustrates how to setup block storage and partition
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.0.0
+  - alien-extended-storage-types:2.1.0-SM6
   - org.ystia.yorc.experimental.consul.linux.ansible:2.1.0-SNAPSHOT
   - org.ystia.yorc.experimental.consul.pub:2.1.0-SNAPSHOT
 

--- a/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
+++ b/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
@@ -92,7 +92,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: agent
-        download_url: "https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"
@@ -122,7 +122,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: server
-        download_url: "https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/consulfs/consul_data"
         config_dir: "/etc/consul.d"

--- a/org/ystia/experimental/consul/topologies/MultiDCWithWAN/types.yaml
+++ b/org/ystia/experimental/consul/topologies/MultiDCWithWAN/types.yaml
@@ -109,7 +109,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: agent
-        download_url: "https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"
@@ -139,7 +139,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: server
-        download_url: "https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"
@@ -234,7 +234,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: server
-        download_url: "https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"
@@ -259,7 +259,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: agent
-        download_url: "https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"

--- a/org/ystia/experimental/consul/topologies/SimpleClientServer/types.yaml
+++ b/org/ystia/experimental/consul/topologies/SimpleClientServer/types.yaml
@@ -88,7 +88,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: agent
-        download_url: "https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"
@@ -118,7 +118,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: server
-        download_url: "https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"

--- a/org/ystia/experimental/consul/topologies/consulClient/client-template.yaml
+++ b/org/ystia/experimental/consul/topologies/consulClient/client-template.yaml
@@ -49,7 +49,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: agent
-        download_url: "https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"

--- a/org/ystia/experimental/consul/topologies/consulService/server-template.yaml
+++ b/org/ystia/experimental/consul/topologies/consulService/server-template.yaml
@@ -54,7 +54,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: server
-        download_url: "https://releases.hashicorp.com/consul/1.0.6/consul_1.0.6_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"

--- a/org/ystia/nfs/pub/types.yaml
+++ b/org/ystia/nfs/pub/types.yaml
@@ -22,7 +22,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.0.0
+  - alien-extended-storage-types:2.1.0-SNAPSHOT
 
 node_types:
   org.ystia.nfs.pub.nodes.NFSServer:

--- a/org/ystia/nfs/pub/types.yaml
+++ b/org/ystia/nfs/pub/types.yaml
@@ -22,7 +22,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.1.0-SNAPSHOT
+  - alien-extended-storage-types:2.1.0-SM6
 
 node_types:
   org.ystia.nfs.pub.nodes.NFSServer:

--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -10,9 +10,9 @@ description: ""
 imports:
 - tosca-normative-types:1.0.0-ALIEN20
 
-- org.alien4cloud.alien4cloud.pub:2.0.0
-- org.alien4cloud.alien4cloud.webapp:2.0.0
-- org.alien4cloud.java.jdk.linux:2.0.0
+- org.alien4cloud.alien4cloud.pub:2.1.0-SNAPSHOT
+- org.alien4cloud.alien4cloud.webapp:2.1.0-SNAPSHOT
+- org.alien4cloud.java.jdk.linux:2.1.0-SNAPSHOT
 
 - org.ystia.terraform.linux.terraform:2.1.0-SNAPSHOT
 - org.ystia.yorc.alien4cloud:2.1.0-SNAPSHOT

--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -10,9 +10,9 @@ description: ""
 imports:
 - tosca-normative-types:1.0.0-ALIEN20
 
-- org.alien4cloud.alien4cloud.pub:2.1.0-SNAPSHOT
-- org.alien4cloud.alien4cloud.webapp:2.1.0-SNAPSHOT
-- org.alien4cloud.java.jdk.linux:2.1.0-SNAPSHOT
+- org.alien4cloud.alien4cloud.pub:2.1.0-SM6
+- org.alien4cloud.alien4cloud.webapp:2.1.0-SM6
+- org.alien4cloud.java.jdk.linux:2.1.0-SM6
 
 - org.ystia.terraform.linux.terraform:2.1.0-SNAPSHOT
 - org.ystia.yorc.alien4cloud:2.1.0-SNAPSHOT

--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -137,7 +137,7 @@ topology_template:
     YorcPlugin:
       type: org.ystia.yorc.alien4cloud.nodes.YorcPlugin
       properties:
-        download_url: "https://github.com/ystia/yorc-a4c-plugin/releases/download/v3.1.0-M1/alien4cloud-yorc-plugin-3.1.0-M1.zip"
+        download_url: "https://github.com/ystia/yorc-a4c-plugin/releases/download/v3.1.0-M3/alien4cloud-yorc-plugin-3.1.0-M3.zip"
         name: Yorc
         discriminator: yorc
         pluginId: "alien4cloud-yorc-plugin"
@@ -156,7 +156,7 @@ topology_template:
     YorcServer:
       type: org.ystia.yorc.linux.ansible.nodes.YorcServer
       properties:
-        download_url: "https://github.com/ystia/yorc/releases/download/v3.1.0-M1/yorc.tgz"
+        download_url: "https://github.com/ystia/yorc/releases/download/v3.1.0-M3/yorc.tgz"
         install_dir: "/usr/local/bin"
         config_dir: "/etc/yorc"
         data_dir: "/var/yorc"
@@ -194,7 +194,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: server
-        download_url: "https://releases.hashicorp.com/consul/1.0.2/consul_1.0.2_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -153,7 +153,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: server
-        download_url: "https://releases.hashicorp.com/consul/1.0.2/consul_1.0.2_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"
@@ -242,7 +242,7 @@ topology_template:
     YorcPlugin:
       type: org.ystia.yorc.alien4cloud.nodes.YorcPlugin
       properties:
-        download_url: "https://github.com/ystia/yorc-a4c-plugin/releases/download/v3.0.0/alien4cloud-yorc-plugin-3.0.0.zip"
+        download_url: "https://github.com/ystia/yorc-a4c-plugin/releases/download/v3.1.0-M3/alien4cloud-yorc-plugin-3.1.0-M3.zip"
         name: Yorc
         discriminator: yorc
         pluginId: "alien4cloud-yorc-plugin"
@@ -343,7 +343,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: agent
-        download_url: "https://releases.hashicorp.com/consul/1.0.2/consul_1.0.2_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"
@@ -373,7 +373,7 @@ topology_template:
       properties:
         install_dnsmasq: true
         mode: agent
-        download_url: "https://releases.hashicorp.com/consul/1.0.2/consul_1.0.2_linux_amd64.zip"
+        download_url: "https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip"
         install_dir: "/usr/local/bin"
         data_dir: "/var/consul"
         config_dir: "/etc/consul.d"
@@ -401,7 +401,7 @@ topology_template:
     YorcServer:
       type: org.ystia.yorc.linux.ansible.nodes.YorcServer
       properties:
-        download_url: "https://github.com/ystia/yorc/releases/download/v3.0.0/yorc.tgz"
+        download_url: "https://github.com/ystia/yorc/releases/download/v3.1.0-M3/yorc.tgz"
         install_dir: "/usr/local/bin"
         config_dir: "/etc/yorc"
         data_dir: "/var/yorc"

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.1.0-SNAPSHOT
+  - alien-extended-storage-types:2.1.0-SM6
 
   - org.alien4cloud.java.pub:2.1.0-SNAPSHOT
   - org.alien4cloud.alien4cloud.pub:2.1.0-SNAPSHOT

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.0.0
+  - alien-extended-storage-types:2.1.0-SNAPSHOT
 
   - org.alien4cloud.java.pub:2.1.0-SNAPSHOT
   - org.alien4cloud.alien4cloud.pub:2.1.0-SNAPSHOT

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -11,11 +11,11 @@ imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - alien-extended-storage-types:2.0.0
 
-  - org.alien4cloud.java.pub:2.0.0
-  - org.alien4cloud.alien4cloud.pub:2.0.0
-  - org.alien4cloud.alien4cloud.webapp:2.0.0
-  - org.alien4cloud.java.jdk.linux:2.0.0
-  - org.alien4cloud.alien4cloud.config.pub:2.0.0
+  - org.alien4cloud.java.pub:2.1.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.pub:2.1.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.webapp:2.1.0-SNAPSHOT
+  - org.alien4cloud.java.jdk.linux:2.1.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.pub:2.1.0-SNAPSHOT
 #  - org.alien4cloud.consul.pub:2.0.0-SNAPSHOT
 #  - org.alien4cloud.elasticsearch.pub:2.0.0-SNAPSHOT
 #  - org.alien4cloud.java.jmx.jolokia:2.0.0-SNAPSHOT

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -11,11 +11,11 @@ imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - alien-extended-storage-types:2.1.0-SM6
 
-  - org.alien4cloud.java.pub:2.1.0-SNAPSHOT
-  - org.alien4cloud.alien4cloud.pub:2.1.0-SNAPSHOT
-  - org.alien4cloud.alien4cloud.webapp:2.1.0-SNAPSHOT
-  - org.alien4cloud.java.jdk.linux:2.1.0-SNAPSHOT
-  - org.alien4cloud.alien4cloud.config.pub:2.1.0-SNAPSHOT
+  - org.alien4cloud.java.pub:2.1.0-SM6
+  - org.alien4cloud.alien4cloud.pub:2.1.0-SM6
+  - org.alien4cloud.alien4cloud.webapp:2.1.0-SM6
+  - org.alien4cloud.java.jdk.linux:2.1.0-SM6
+  - org.alien4cloud.alien4cloud.config.pub:2.1.0-SM6
 #  - org.alien4cloud.consul.pub:2.0.0-SNAPSHOT
 #  - org.alien4cloud.elasticsearch.pub:2.0.0-SNAPSHOT
 #  - org.alien4cloud.java.jmx.jolokia:2.0.0-SNAPSHOT

--- a/org/ystia/topologies/elk_ha/types.yml
+++ b/org/ystia/topologies/elk_ha/types.yml
@@ -14,7 +14,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.0.0
+  - alien-extended-storage-types:2.1.0-SM6
 
   - org.ystia.common:2.1.0-SNAPSHOT
   - org.ystia.java.pub:2.1.0-SNAPSHOT

--- a/org/ystia/topologies/jupyter/types.yml
+++ b/org/ystia/topologies/jupyter/types.yml
@@ -13,7 +13,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.0.0
+  - alien-extended-storage-types:2.1.0-SM6
   - org.ystia.common:2.1.0-SNAPSHOT
   - org.ystia.python.pub:2.1.0-SNAPSHOT
   - org.ystia.python.linux.bash:2.1.0-SNAPSHOT

--- a/org/ystia/topologies/rstudio/types.yml
+++ b/org/ystia/topologies/rstudio/types.yml
@@ -13,7 +13,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.0.0
+  - alien-extended-storage-types:2.1.0-SM6
   - org.ystia.common:2.1.0-SNAPSHOT
   - org.ystia.java.pub:2.1.0-SNAPSHOT
   - org.ystia.java.linux.bash:2.1.0-SNAPSHOT

--- a/org/ystia/yorc/alien4cloud/types.yaml
+++ b/org/ystia/yorc/alien4cloud/types.yaml
@@ -6,11 +6,11 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - org.alien4cloud.alien4cloud.pub:2.1.0-SNAPSHOT
-  - org.alien4cloud.alien4cloud.config.pub:2.1.0-SNAPSHOT
-  - org.alien4cloud.alien4cloud.config.location:2.1.0-SNAPSHOT
-  - org.alien4cloud.alien4cloud.config.location_resources.on_demand:2.1.0-SNAPSHOT
-  - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:2.1.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.pub:2.1.0-SM6
+  - org.alien4cloud.alien4cloud.config.pub:2.1.0-SM6
+  - org.alien4cloud.alien4cloud.config.location:2.1.0-SM6
+  - org.alien4cloud.alien4cloud.config.location_resources.on_demand:2.1.0-SM6
+  - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:2.1.0-SM6
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.0.0
   - org.ystia.yorc.pub:2.1.0-SNAPSHOT

--- a/org/ystia/yorc/alien4cloud/types.yaml
+++ b/org/ystia/yorc/alien4cloud/types.yaml
@@ -6,11 +6,11 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - org.alien4cloud.alien4cloud.pub:2.0.0
-  - org.alien4cloud.alien4cloud.config.pub:2.0.0
-  - org.alien4cloud.alien4cloud.config.location:2.0.0
-  - org.alien4cloud.alien4cloud.config.location_resources.on_demand:2.0.0
-  - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:2.0.0
+  - org.alien4cloud.alien4cloud.pub:2.1.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.pub:2.1.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location:2.1.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location_resources.on_demand:2.1.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:2.1.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.0.0
   - org.ystia.yorc.pub:2.1.0-SNAPSHOT


### PR DESCRIPTION
# Pull Request description

## Description of the change

Updated dependencies. The forge requires now :
  * Alien4Cloud 2.1.0-SM6
  * Alien4Cloud CSAR public library 2.1.0-SM6

Updated Forge Consul components at org/ystia/experimental/consul/ to install Consul 1.2.3

### How I verified it

Using an Alien4Cloud 2.1.0-SM6, the latest Yorc Alien4Cloud plugin and latest yorc.

In Alien4Cloud Archive Management,
  * imported https://github.com/alien4cloud/csar-public-library.git tag v2.1.0-SM6 folder org/alien4cloud (known issues are reported but not preventing uploads)
  * imported https://github.com/ystia/forge.git branch feature/alien4cloud-2.1.0 folder org/ystia
Created an Application from topology a4c_yorc_basic, removed the Alien4Cloud component, to just keep the Yorc component and its dependencies
Deployed this application on an OpenStack location
