### PR TITLE
Feature/gh 23 bootstrap yorc gce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## UNRELEASED
 
-## 2.1.0-M4 (October 08, 2018)
+### NEW COMPONENTS
+
+* Google Compute Engine Infrastructure configuration ([GH-23](https://github.com/ystia/forge/issues/23))
 
 ### DEPENDENCIES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Google Compute Engine Infrastructure configuration ([GH-23](https://github.com/ystia/forge/issues/23))
 
+## 2.1.0-M4 (October 08, 2018)
+
 ### DEPENDENCIES
 
 * Ystia Forge components require now Alien4Cloud 2.1.0-SM6

--- a/org/ystia/yorc/README.rst
+++ b/org/ystia/yorc/README.rst
@@ -54,6 +54,28 @@ Capabilities
 
 - **config**: Allows to host configuration fragments (e.g. infrastructures)
 
+GoogleConfig Component
+----------------------
+
+GoogleConfig component allows to add a Google Compute Engine infrastructure to Yorc configuration.
+
+Properties
+^^^^^^^^^^
+
+- **project** : ID of the Google Cloud project to apply any resources to
+
+- **region** : The Google Cloud region where to create resources
+
+- **application_credentials** : Path to file containing service account private keys in JSON format
+
+- **credentials** : Content of file containing service account private keys in JSON format
+
+
+Requirements
+^^^^^^^^^^^^
+
+- **host**: GoogleConfig should be hosted on a YorcServer component.
+
 OpenStackConfig Component
 -------------------------
 
@@ -86,7 +108,7 @@ Requirements
 KubernetesConfig Component
 --------------------------
 
-The OpenStackConfig component allows to add OpenStack infrastructure to the configuration of Yorc
+The KubernetesConfig component allows to add a Kubernetes infrastructure to the configuration of Yorc
 
 Properties
 ^^^^^^^^^^
@@ -105,13 +127,13 @@ Properties
 Requirements
 ^^^^^^^^^^^^
 
-- **host**: OpenStackConfig should be hosted on a YorcServer component.
+- **host**: KubernetesConfig should be hosted on a YorcServer component.
 
 
 AWSConfig Component
 -------------------
 
-The OpenStackConfig component allows to add OpenStack infrastructure to the configuration of Yorc
+The AWSConfig component allows to add an AWS infrastructure to the configuration of Yorc
 
 Properties
 ^^^^^^^^^^
@@ -125,5 +147,5 @@ Properties
 Requirements
 ^^^^^^^^^^^^
 
-- **host**: OpenStackConfig should be hosted on a YorcServer component.
+- **host**: AWSConfig should be hosted on a YorcServer component.
 

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_google.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_google.yml
@@ -1,0 +1,39 @@
+#
+# Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+- name: Setup Google Infrastrucutre configuration
+  hosts: all
+  strategy: free
+  become_user: yorc
+  become: true
+  tasks:
+    - name: "get current config of Yorc"
+      shell: "cat {{ CONFIG_DIR }}/config.yorc.yaml"
+      register: result
+
+    - set_fact:
+        yorcConfig: "{{ result.stdout | from_yaml }}"
+
+    - set_fact:
+        tmp: '{ "infrastructures": { "google": { "project": "{{ PROJECT }}", "region": "{{ REGION }}", "application_credentials": "{{ APPLICATION_CREDENTIALS }}", "credentials": "{{ CREDENTIALS }}" } } }'
+    - set_fact:
+        yorcConfig: "{{ yorcConfig | combine(tmp, recursive=True) }}"
+
+    - name: "Output config to file {{ CONFIG_DIR }}/config.yorc.yaml"
+      copy:
+        content: "{{ yorcConfig | to_yaml }}"
+        dest: "{{ CONFIG_DIR }}/config.yorc.yaml"

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_google.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_google.yml
@@ -15,7 +15,7 @@
 #
 
 
-- name: Setup Google Infrastrucutre configuration
+- name: Setup Google Infrastructure configuration
   hosts: all
   strategy: free
   become_user: yorc

--- a/org/ystia/yorc/yorc/linux/ansible/types.yaml
+++ b/org/ystia/yorc/yorc/linux/ansible/types.yaml
@@ -29,6 +29,14 @@ imports:
 
 
 node_types:
+  org.ystia.yorc.infrastructure.GoogleConfig:
+    derived_from: org.ystia.yorc.pub.infrastructure.GoogleConfig
+    requirements:
+    - host:
+        capability: org.ystia.yorc.pub.capabilities.YorcConfigContainer
+        relationship: org.ystia.yorc.linux.ansible.relationships.YorcConfigGoogleHostedOnYorc
+        occurrences: [ 1, 1 ]
+
   org.ystia.yorc.infrastructure.OpenStackConfig:
     derived_from: org.ystia.yorc.pub.infrastructure.OpenStackConfig
     requirements:
@@ -123,6 +131,20 @@ relationship_types:
             CONFIG_DIR: { get_property: [SOURCE, config_dir] }
             PLUGINS_DIR: { get_property: [TARGET, plugins_dir] }
           implementation: playbooks/configure_terraform.yml
+  org.ystia.yorc.linux.ansible.relationships.YorcConfigGoogleHostedOnYorc:
+    derived_from: tosca.relationships.HostedOn
+    description: >
+      Configure a Yorc server with a Google Compute Engine infrastructure
+    valid_target_types: [ org.ystia.yorc.pub.nodes.YorcServer ]
+    interfaces:
+      Configure:
+        post_configure_target:
+          inputs:
+            PROJECT: { get_property: [SOURCE, project] }
+            REGION: { get_property: [SOURCE, region] }
+            APPLICATION_CREDENTIALS: { get_property: [SOURCE, application_credentials] }
+            CREDENTIALS: { get_property: [SOURCE, credentials] }
+          implementation: playbooks/configure_google.yml
   org.ystia.yorc.linux.ansible.relationships.YorcConfigOpenstackHostedOnYorc:
     derived_from: tosca.relationships.HostedOn
     description: >

--- a/org/ystia/yorc/yorc/pub/types.yaml
+++ b/org/ystia/yorc/yorc/pub/types.yaml
@@ -27,6 +27,33 @@ imports:
   - org.ystia.terraform.pub:2.1.0-SNAPSHOT
 
 node_types:
+  org.ystia.yorc.pub.infrastructure.GoogleConfig:
+    derived_from: tosca.nodes.Root
+    description: |
+      Google Compute Engine Infrastructure configuration for Yorc
+    abstract: true
+    properties:
+      project:
+        description: "The Google Cloud project to use."
+        type: string
+        required: true
+      region:
+        description: "The Google Compute Engine region to use."
+        type: string
+        required: false
+      application_credentials:
+        description: "Path to file containing service account private keys in JSON format."
+        type: string
+        required: false
+      credentials:
+        description: "Content of file containing service account private keys."
+        type: string
+        required: false
+    requirements:
+    - host:
+        capability: org.ystia.yorc.pub.capabilities.YorcConfigContainer
+        relationship: org.ystia.yorc.pub.relationships.YorcConfigHostedOnYorc
+        occurrences: [ 1, 1 ]
   org.ystia.yorc.pub.infrastructure.OpenStackConfig:
     derived_from: tosca.nodes.Root
     description: |


### PR DESCRIPTION
Similarly to what was done already for AWS, OpenStack and Kubernetes,
added a GoogleConfig component to add a Google Compute Engine infrastructure to Yorc configuration.
This is needed to bootstrap Yorc on Google Compute engine, (Yorc issue https://github.com/ystia/yorc/issues/131)