### PR TITLE
Relying on ansible easy_install to install pip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Yorc AnsibleRuntime component creation fails on CentOS 7 on AWS ([GH-30](https://github.com/ystia/forge/issues/30))
+
+
 ## 2.1.0-M5 (October 26, 2018)
 
 ### NEW COMPONENTS

--- a/org/ystia/ansible/linux/ansible/playbooks/create.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/create.yml
@@ -33,6 +33,11 @@
         state: present
       with_items: "{{install_packages}}"
 
+    - name: Install pip
+      easy_install:
+        name: pip
+        state: latest
+
     - name: install using pip
       pip:
         name: ansible

--- a/org/ystia/ansible/linux/ansible/playbooks/vars/Debian.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/vars/Debian.yml
@@ -20,4 +20,3 @@ install_packages:
   - python2
   - python2-dev
   - virtualenv
-  - python-pip

--- a/org/ystia/ansible/linux/ansible/playbooks/vars/RedHat.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/vars/RedHat.yml
@@ -20,4 +20,3 @@ install_packages:
   - python2
   - python2-devel
   - python-virtualenv
-  - python2-pip


### PR DESCRIPTION
Instead of installing a distribution-dependent package for pip, which failed on AWS when attempting to find a python2-pip package for CentOS 7, relying on ansible easy_install to install pip.

Validated the AnsibleRuntime component could be installed correctly on AWS with this change.

Related issue: https://github.com/ystia/forge/issues/30
