### PR TITLE
Specifying download url instead of version in Terraform component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* TerraformRuntime component should have a download URL in argument ([GH-22](https://github.com/ystia/forge/issues/22))
+
 ## 2.1.0-M6 (November 16, 2018)
 
 ### DEPENDENCIES

--- a/org/ystia/terraform/README.rst
+++ b/org/ystia/terraform/README.rst
@@ -17,11 +17,15 @@ The TerraformRuntime component install the terraform binary
 Properties
 ^^^^^^^^^^
 
+- **download_url** : Terraform download URL.
+  Providing a value different from the default value allows to specify an alternative repository (ie: for offline installations).
+  It is your responsibility to provide an accessible download url and to store required artifacts on it.
+
+  - Default : https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip
+
 - **install_dir**: Directory where Terraform binary should be installed
 
   - Default : /usr/local/bin
-
-- **component_version**: Version of Terraform to install.
 
 - **plugins_dir**: Directory where are located Terraform plugins
 

--- a/org/ystia/terraform/linux/ansible/playbooks/create.yml
+++ b/org/ystia/terraform/linux/ansible/playbooks/create.yml
@@ -42,7 +42,7 @@
 
     - name: Download Terraform binary
       get_url:
-        url: "https://releases.hashicorp.com/terraform/{{ TERRAFORM_VERSION }}/terraform_{{ TERRAFORM_VERSION }}_linux_amd64.zip"
+        url: "{{ DOWNLOAD_URL }}"
         dest: /tmp/terraform.zip
 
     - name: copy Terraform bin

--- a/org/ystia/terraform/linux/ansible/types.yaml
+++ b/org/ystia/terraform/linux/ansible/types.yaml
@@ -31,7 +31,7 @@ node_types:
     interfaces:
       Standard:
         inputs:
-          TERRAFORM_VERSION: { get_property: [SELF, component_version] }
+          DOWNLOAD_URL: { get_property: [SELF, download_url] }
           INSTALL_DIR: { get_property: [SELF, install_dir] }
           PLUGINS_DIR: { get_property: [SELF, plugins_dir] }
           PLUGINS_DOWNLOAD_URLS: { get_property: [SELF, plugins_download_urls] }

--- a/org/ystia/terraform/pub/types.yaml
+++ b/org/ystia/terraform/pub/types.yaml
@@ -30,10 +30,11 @@ node_types:
     tags:
       icon: terraform.jpg
     properties:
-      component_version:
-        type: version
+      download_url:
+        description: Terraform download URL
+        type: string
         required: true
-        default: 0.11.8
+        default: "https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip"
       install_dir:
         description: Installation directory for the Terraform binary
         type: string

--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -218,7 +218,7 @@ topology_template:
     TerraformRuntime:
       type: org.ystia.terraform.linux.terraform.nodes.TerraformRuntime
       properties:
-        component_version: "0.11.8"
+        download_url: "https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip"
         install_dir: "/usr/local/bin"
       requirements:
       - hostedOnA4CYorcHost:

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -284,7 +284,7 @@ topology_template:
     TerraformRuntime:
       type: org.ystia.terraform.linux.terraform.nodes.TerraformRuntime
       properties:
-        component_version: "0.11.8"
+        download_url: "https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip"
         install_dir: "/usr/local/bin"
       requirements:
       - hostedOnComputeYorcHost:


### PR DESCRIPTION
Removed Terraform component property `version`  and introduced new property `download_url`, to be able to use an internal download repository, useful for performance enhancements or if external acces is disabled.