### PR TITLE
Using server private address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Component NFS Client fails to mount directory exported by NFS server on GCP ([GH-38](https://github.com/ystia/forge/issues/38))
+
 ## 2.1.0-M7 (December 07, 2018)
 
 ### NEW FEATURES

--- a/org/ystia/nfs/linux/ansible/types.yaml
+++ b/org/ystia/nfs/linux/ansible/types.yaml
@@ -56,6 +56,6 @@ relationship_types:
       Configure:
         inputs:
           DIRECTORY: { get_property: [SOURCE, location] }
-          SERVER_IP: { get_attribute: [TARGET, ip_address ] }
+          SERVER_IP: { get_attribute: [TARGET, private_address ] }
         pre_configure_source:
           implementation: playbooks/join_server.yml


### PR DESCRIPTION
Fixing the deployment failure of a NFS client/NFS server application on GCP where the NFS client attempts (and fail) to mount the NFS server exported file system using the NFS server public IP address instead of the NFS server private IP address.
