### PR TITLE
Bugfix/rhel support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### BUG FIXES
+
+* Forge components installing dnsmaq fail on RHEL 7.5  ([GH-44](https://github.com/ystia/forge/issues/44))
+
 ### DEPENDENCIES
 
 * Ystia Forge components require now Alien4Cloud 2.1.0

--- a/org/ystia/dns/dnsmaq/ansible/playbooks/roles/jriguera.dnsmasq/tasks/main.yml
+++ b/org/ystia/dns/dnsmaq/ansible/playbooks/roles/jriguera.dnsmasq/tasks/main.yml
@@ -5,7 +5,8 @@
      ansible_distribution != 'Ubuntu' and
      ansible_distribution != 'CentOS' and
      ansible_distribution != 'Debian' and
-     ansible_distribution != 'Red Hat Enterprise Linux'
+     ansible_distribution != 'Red Hat Enterprise Linux' and
+     ansible_distribution != 'RedHat'
 
 - name: Include OS specific variables
   include_vars: "{{ ansible_os_family }}.yml"

--- a/org/ystia/experimental/consul/linux/ansible/playbooks/roles/jriguera.dnsmasq/tasks/main.yml
+++ b/org/ystia/experimental/consul/linux/ansible/playbooks/roles/jriguera.dnsmasq/tasks/main.yml
@@ -5,7 +5,8 @@
      ansible_distribution != 'Ubuntu' and
      ansible_distribution != 'CentOS' and
      ansible_distribution != 'Debian' and
-     ansible_distribution != 'Red Hat Enterprise Linux'
+     ansible_distribution != 'Red Hat Enterprise Linux' and
+     ansible_distribution != 'RedHat'
 
 - name: Include OS specific variables
   include_vars: "{{ ansible_os_family }}.yml"


### PR DESCRIPTION
Changed the ansible playbook dnsmasq role code so that the `ansible_distribution` value `RedHat` is accepted as this is the values returned now on Red Hat Enterprise Linux 7.5. 