### PR TITLE
Bugfix/a4c 2 1 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## UNRELEASED
 
+### DEPENDENCIES
+
+* Ystia Forge components require now Alien4Cloud CSAR public library 2.2.0-SNAPSHOT
+
+### BUG FIXES
+
+* Several wrong version referenced for csar-public-lib components ([GH-58](https://github.com/ystia/forge/issues/58))
+
+
+## 2.1.0 (December 20, 2018)
+
 ### BUG FIXES
 
 * Kafka download URLs no more valid ([GH-41](https://github.com/ystia/forge/issues/41))

--- a/org/ystia/experimental/consul/pub/types.yaml
+++ b/org/ystia/experimental/consul/pub/types.yaml
@@ -23,7 +23,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.alien4cloud.consul.pub:2.1.0
+  - org.alien4cloud.consul.pub:2.2.0-SNAPSHOT
 
 description: >
   This component exposes public interfaces for Consul

--- a/org/ystia/experimental/consul/topologies/SecuredClientServer/types.yaml
+++ b/org/ystia/experimental/consul/topologies/SecuredClientServer/types.yaml
@@ -27,7 +27,7 @@ imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.experimental.consul.linux.ansible:2.2.0-SNAPSHOT
   - org.ystia.yorc.experimental.consul.pub:2.2.0-SNAPSHOT
-  - org.alien4cloud.consul.pub:2.1.0
+  - org.alien4cloud.consul.pub:2.2.0-SNAPSHOT
   - yorc-types:1.0.0
 
 topology_template:

--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -10,9 +10,9 @@ description: ""
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
 
-  - org.alien4cloud.alien4cloud.pub:2.1.0
-  - org.alien4cloud.alien4cloud.webapp:2.1.0
-  - org.alien4cloud.java.jdk.linux:2.1.0
+  - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.webapp:2.2.0-SNAPSHOT
+  - org.alien4cloud.java.jdk.linux:2.2.0-SNAPSHOT
 
   - org.ystia.terraform.linux.terraform:2.2.0-SNAPSHOT
   - org.ystia.yorc.alien4cloud:2.2.0-SNAPSHOT

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -11,11 +11,11 @@ imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - alien-extended-storage-types:2.1.0
 
-  - org.alien4cloud.java.pub:2.1.0
-  - org.alien4cloud.alien4cloud.pub:2.1.0
-  - org.alien4cloud.alien4cloud.webapp:2.1.0
-  - org.alien4cloud.java.jdk.linux:2.1.0
-  - org.alien4cloud.alien4cloud.config.pub:2.1.0
+  - org.alien4cloud.java.pub:2.2.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.webapp:2.2.0-SNAPSHOT
+  - org.alien4cloud.java.jdk.linux:2.2.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.pub:2.2.0-SNAPSHOT
 #  - org.alien4cloud.consul.pub:2.0.0-SNAPSHOT
 #  - org.alien4cloud.elasticsearch.pub:2.0.0-SNAPSHOT
 #  - org.alien4cloud.java.jmx.jolokia:2.0.0-SNAPSHOT

--- a/org/ystia/yorc/alien4cloud/types.yaml
+++ b/org/ystia/yorc/alien4cloud/types.yaml
@@ -6,11 +6,11 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - org.alien4cloud.alien4cloud.pub:2.1.0
-  - org.alien4cloud.alien4cloud.config.pub:2.1.0
-  - org.alien4cloud.alien4cloud.config.location:2.1.0
-  - org.alien4cloud.alien4cloud.config.location_resources.on_demand:2.1.0
-  - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:2.1.0
+  - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.pub:2.2.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location:2.2.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location_resources.on_demand:2.2.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.0.0
   - org.ystia.yorc.pub:2.2.0-SNAPSHOT


### PR DESCRIPTION
Fixing several failures when attempting to upload this library in Alien4Cloud because of wrong version 2.1.0 references for csar-public-library components, while 2.2.0-SNAPSHOT is expected.

Fixes issue https://github.com/ystia/forge/issues/58