### PR TITLE
A4c loadtests

### DIFF
--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_telemetry_statsd.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_telemetry_statsd.yml
@@ -1,0 +1,39 @@
+#
+# Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+- name: Setup Statsd Telemetry config
+  hosts: all
+  strategy: free
+  become_user: yorc
+  become: true
+  tasks:
+    - name: "get current config of Yorc"
+      shell: "cat {{ CONFIG_DIR }}/config.yorc.yaml"
+      register: result
+
+    - set_fact:
+        yorcConfig: "{{ result.stdout | from_yaml }}"
+
+    - set_fact:
+        tmp: '{ "telemetry": { "statsd_address": "{{ STATSD_IP_ADDRESS }}:{{ STATSD_IP_PORT }}", "disable_hostname": true } }'
+    - set_fact:
+        yorcConfig: "{{ yorcConfig | combine(tmp, recursive=True) }}"
+
+    - name: "Output config to file {{ CONFIG_DIR }}/config.yorc.yaml"
+      copy:
+        content: "{{ yorcConfig | to_yaml }}"
+        dest: "{{ CONFIG_DIR }}/config.yorc.yaml"

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/create.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/create.yml
@@ -28,7 +28,7 @@
   become: true
   become_method: sudo
   tasks:
-   
+
     - name: create Yorc group
       group: name=yorc
 
@@ -61,6 +61,14 @@
         group: yorc
         mode: "u=rwx,g=rwx,o=rx"
 
+    - name: Setup permissions on log dir
+      file:
+        path: "{{LOG_DIR}}"
+        state: directory
+        owner: yorc
+        group: yorc
+        mode: "u=rwx,g=rwx,o=rx"
+
     - name: Download Yorc binary
       get_url:
         url: "{{DOWNLOAD_URL}}"
@@ -75,7 +83,7 @@
         mode: "u=rx,g=rx,o=rx"
 
     - name: Install Yorc systemd unit
-      template: 
+      template:
         src: yorc.service.j2
         dest: "/etc/systemd/system/yorc.service"
         mode: "u=rw,g=rw,o=r"

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/templates/config.yorc.yaml.j2
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/templates/config.yorc.yaml.j2
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 #}
 resources_prefix: yorc-
+workers_number: {{WORKERS_NUMBER}}
 http_port: "{{REST_API_PORT}}"
 server_id: "{{server_id}}"
 {% if  REST_API_PROTOCOL == "https" %}
@@ -22,3 +23,8 @@ key_file: "{{CONFIG_DIR}}/yorc_server.key"
 cert_file: "{{CONFIG_DIR}}/yorc_server.pem"
 ca_file: "{{CONFIG_DIR}}/yorc_ca.pem"
 {% endif %}
+ansible:
+  use_openssh: {{ANSIBLE_USE_OPENSSH}}
+  connection_retries: {{ANSIBLE_CONNECTION_RETRIES}}
+  hosted_operations:
+    unsandboxed_operations_allowed: {{ANSIBLE_HOSTED_OPERATIONS_UNSANDBOXED_OPERATIONS_ALLOWED}}

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/templates/config.yorc.yaml.j2
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/templates/config.yorc.yaml.j2
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 #}
-resources_prefix: yorc-
+resources_prefix: {{RESOURCES_PREFIX}}
 workers_number: {{WORKERS_NUMBER}}
 http_port: "{{REST_API_PORT}}"
 server_id: "{{server_id}}"

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/templates/yorc.service.j2
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/templates/yorc.service.j2
@@ -26,10 +26,11 @@ Environment="NO_PROXY={% if ansible_env['NO_PROXY'] is defined %}{{ansible_env['
 User=yorc
 Group=yorc
 Restart=on-failure
-ExecStart={{INSTALL_DIR}}/yorc server -c {{CONFIG_DIR}}/config.yorc.yaml
+ExecStart=/bin/bash -c '{{INSTALL_DIR}}/yorc server -c {{CONFIG_DIR}}/config.yorc.yaml 2>&1 >> {{LOG_DIR}}/yorc.log'
 KillSignal=SIGINT
 TimeoutStopSec=360
 WorkingDirectory=/var/yorc
+LimitNOFILE=65536
 
 [Install]
 WantedBy=multi-user.target

--- a/org/ystia/yorc/yorc/linux/ansible/types.yaml
+++ b/org/ystia/yorc/yorc/linux/ansible/types.yaml
@@ -106,6 +106,12 @@ node_types:
         type: boolean
         required: true
         default: false
+      resources_prefix:
+        type: string
+        description: |
+          Specify a prefix that will be used for names when creating resources such as Compute instances or volumes.
+        required: true
+        default: "yorc-"
     interfaces:
       Standard:
         inputs:
@@ -124,6 +130,7 @@ node_types:
             IP_ADDRESS: { get_attribute: [HOST, private_address] }
             PUBLIC_ADDRESS: { get_attribute: [HOST, public_address] }
             WORKERS_NUMBER: { get_property: [SELF, workers_number] }
+            RESOURCES_PREFIX: { get_property: [SELF, resources_prefix] }
             ANSIBLE_USE_OPENSSH: { get_property: [SELF, ansible_use_openssh] }
             ANSIBLE_CONNECTION_RETRIES: { get_property: [SELF, ansible_connection_retries] }
             ANSIBLE_HOSTED_OPERATIONS_UNSANDBOXED_OPERATIONS_ALLOWED: { get_property: [SELF, ansible_hosted_operations_unsandboxed_operations_allowed] }

--- a/org/ystia/yorc/yorc/linux/ansible/types.yaml
+++ b/org/ystia/yorc/yorc/linux/ansible/types.yaml
@@ -26,7 +26,8 @@ imports:
   - yorc-types:1.0.0
   - org.ystia.yorc.pub:2.2.0-SNAPSHOT
   - org.ystia.yorc.experimental.consul.pub:2.2.0-SNAPSHOT
-
+  - org.alien4cloud.statsd.pub:2.2.0-SNAPSHOT
+  - org.alien4cloud.grafana.pub:2.2.0-SNAPSHOT
 
 node_types:
   org.ystia.yorc.infrastructure.GoogleConfig:
@@ -80,12 +81,38 @@ node_types:
     description: Yorc server instance
     metadata:
       icon: "yorcicon.png"
+    properties:
+      log_dir:
+        type: string
+        required: true
+        default: "/var/log/yorc"
+      ansible_use_openssh:
+        description: |
+          Prefer OpenSSH over Paramiko a Python implementation of SSH (the default) to provision remote hosts.
+          OpenSSH have several optimization like reusing connections that should improve preformance but may lead to issues on older systems.
+        type: boolean
+        required: true
+        default: true
+      ansible_connection_retries:
+        description: |
+          Number of retries in case of Ansible SSH connection failure.
+        type: integer
+        required: true
+        default: 3
+      ansible_hosted_operations_unsandboxed_operations_allowed:
+        description: |
+          This option control if operations can be executed directly on the system that hosts Yorc if no default sandbox is defined.
+          This is not permitted by default.
+        type: boolean
+        required: true
+        default: false
     interfaces:
       Standard:
         inputs:
           CONFIG_DIR: { get_property: [SELF, config_dir] }
           INSTALL_DIR: { get_property: [SELF, install_dir] }
           DATA_DIR: { get_property: [SELF, data_dir] }
+          LOG_DIR: { get_property: [SELF, log_dir] }
         create:
           inputs:
             DOWNLOAD_URL: { get_property: [SELF, download_url] }
@@ -96,6 +123,10 @@ node_types:
             REST_API_PROTOCOL: { get_property: [SELF, rest, protocol] }
             IP_ADDRESS: { get_attribute: [HOST, private_address] }
             PUBLIC_ADDRESS: { get_attribute: [HOST, public_address] }
+            WORKERS_NUMBER: { get_property: [SELF, workers_number] }
+            ANSIBLE_USE_OPENSSH: { get_property: [SELF, ansible_use_openssh] }
+            ANSIBLE_CONNECTION_RETRIES: { get_property: [SELF, ansible_connection_retries] }
+            ANSIBLE_HOSTED_OPERATIONS_UNSANDBOXED_OPERATIONS_ALLOWED: { get_property: [SELF, ansible_hosted_operations_unsandboxed_operations_allowed] }
             SSH_KEY: { get_property: [SELF, private_key_content] }
             CA_PEM: { get_property: [SELF, ca_pem] }
             CA_KEY: { get_property: [SELF, ca_key] }
@@ -118,6 +149,10 @@ node_types:
           capability: tosca.capabilities.Node
           relationship: org.ystia.yorc.linux.ansible.relationships.DependsOnTerraformRuntime
           occurrences: [ 1, 1 ]
+      - statsd:
+          capability: org.alien4cloud.statsd.pub.capabilities.StatsdEndpoint
+          relationship: org.ystia.yorc.linux.ansible.relationships.ConnectsToStatsd
+          occurrences: [ 0, 1 ]
 
 relationship_types:
   org.ystia.yorc.linux.ansible.relationships.JoinConsulAgent:
@@ -231,3 +266,16 @@ relationship_types:
             DATA_DIR: { get_property: [TARGET, data_dir] }
             HOSTS_POOL: { get_property: [SOURCE, hosts] }
           implementation: playbooks/configure_hostspool.yml
+
+  org.ystia.yorc.linux.ansible.relationships.ConnectsToStatsd:
+    derived_from: tosca.relationships.ConnectsTo
+    description: >
+      When Yorc is connected to statsd, we fill it's telemetry configuration
+    interfaces:
+      Configure:
+        post_configure_source:
+          inputs:
+            CONFIG_DIR: { get_property: [SOURCE, config_dir] }
+            STATSD_IP_ADDRESS: { get_attribute: [TARGET, statsd_endpoint, ip_address] }
+            STATSD_IP_PORT: { get_attribute: [TARGET, statsd_endpoint, port] }
+          implementation: playbooks/configure_telemetry_statsd.yml

--- a/org/ystia/yorc/yorc/pub/types.yaml
+++ b/org/ystia/yorc/yorc/pub/types.yaml
@@ -184,6 +184,11 @@ node_types:
         type: string
         required: true
         default: /var/yorc
+      workers_number:
+        description: The number of workers to handle executions
+        type: integer
+        required: true
+        default: 30
       private_key_content:
         description: "Content of the default ssh private key used to connect on computes. Stored as ~/.ssh/yorc.pem"
         type: string


### PR DESCRIPTION
# Pull Request description

- Add the ability to configure worker number
- Configure log dir and make yorc write its logs in it
- Add a LimitNOFILE in the service file
- Add a StatsD requirement and relatioship to publish telemetry data and a grafana requirement to add a dashboard
- resources prefix is now a property of Yorc server component

### Dependency issues

This branch has dependencies with https://github.com/alien4cloud/csar-public-library/tree/a4c_loadtests (StatsD type). We have now cyclic dependencies between ystia forge and csar-public-library !