### PR TITLE
Bugfix/gh 88 empty playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ### BUG FIXES
 
+* Empty playbook configure_hostspool_secrets.yml causes error ([GH-88](https://github.com/ystia/forge/issues/88))
 * Install a newer version of Anaconda (Python Component) in order to fix dependencies issues ([GH-69](https://github.com/ystia/forge/issues/69))
 * Several wrong version referenced for csar-public-lib components ([GH-58](https://github.com/ystia/forge/issues/58))
 * Jupyter depends on EPEL repository but do not ensure that it is installed ([GH-70](https://github.com/ystia/forge/issues/70))

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/apply_hostspool.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/apply_hostspool.yml
@@ -20,5 +20,5 @@
   become_user: yorc
   become: true
   tasks:
-    - name: Apply {{ CONFIG_DIR }}/hostspool.yaml definition
-      command: {{INSTALL_DIR}}/yorc hostspool apply {{ CONFIG_DIR }}/hostspool.yaml --auto-approve 
+    - name: "Apply {{ YORC_CONFIG_DIR }}/hostspool.yaml definition"
+      command: "{{ YORC_INSTALL_DIR }}/yorc hostspool apply {{ YORC_CONFIG_DIR }}/hostspool.yaml --auto-approve"

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_hostspool_secrets.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_hostspool_secrets.yml
@@ -14,4 +14,9 @@
 # limitations under the License.
 #
 
-# No secret yet configured on vault for Hosts Pool
+- name: Configure Hosts Pool secrets
+  hosts: all
+  strategy: free
+  tasks:
+    - debug:
+        msg: "No secret yet configured on Vault for Hosts Pool"


### PR DESCRIPTION
# Pull Request description


## Description of the change

Fixed issues attempting to use Hosts Pool infrastructure component :
  * empty playbook configuring secrets as there is no secret yet sotred in Vault for hosts pool, but the playbook should not be empty
  * wrong variable names referenced in playbook applying to Hosts Pool definition

### How to verify it

These fixes are embedded in Yorc Pull Request https://github.com/ystia/yorc/pull/405 and can be verified running a bootstrap on a Hosts Pool

### Description for the changelog

Empty playbook configure_hostspool_secrets.yml causes error ([GH-88](https://github.com/ystia/forge/issues/88))

## Applicable Issues

Fixes #88
