### PR TITLE
Use version 2.2.0-SM6 for alien built-in types and artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@
 
 ### DEPENDENCIES
 
-* Ystia Forge components require now Alien4Cloud 2.1.1 ([GH-64](https://github.com/ystia/forge/issues/64))
-* Ystia Forge components require now Alien4Cloud CSAR public library 2.2.0-SNAPSHOT
+* Ystia Forge components require now Alien4Cloud 2.2.0 ([GH-95](https://github.com/ystia/forge/issues/GH-95))
+* Ystia Forge components require now Alien4Cloud CSAR public library 2.2.0
 * Ystia Forge components require now yorc-types 1.1.0 (GH-82](https://github.com/ystia/forge/pull/82))
 
 ### BUG FIXES

--- a/org/ystia/docker/ansible/types.yml
+++ b/org/ystia/docker/ansible/types.yml
@@ -14,7 +14,7 @@ metadata:
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 node_types:
   org.ystia.docker.ansible.nodes.Docker:

--- a/org/ystia/docker/containers/generic/types.yml
+++ b/org/ystia/docker/containers/generic/types.yml
@@ -16,7 +16,7 @@ metadata:
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - docker-types:2.1.1
+  - docker-types:2.2.0-SM6
 
 node_types:
   org.ystia.docker.containers.docker.generic.nodes.GenricContainer:

--- a/org/ystia/docker/topologies/secured-docker-registry/types.yml
+++ b/org/ystia/docker/topologies/secured-docker-registry/types.yml
@@ -11,8 +11,8 @@ imports:
   - org.ystia.docker.containers.docker.generic:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.ssl.ansible.certificates:2.2.0-SNAPSHOT
-  - alien-extended-storage-types:2.1.1
-  - docker-types:2.1.1
+  - alien-extended-storage-types:2.2.0-SM6
+  - docker-types:2.2.0-SM6
   - org.ystia.docker.ansible:2.2.0-SNAPSHOT
   - org.ystia.docker.containers.docker.registry:2.2.0-SNAPSHOT
   - yorc-types:1.1.0

--- a/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
+++ b/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
@@ -25,7 +25,7 @@ description: "This topology illustrates how to setup block storage and partition
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.1.1
+  - alien-extended-storage-types:2.2.0-SM6
   - org.ystia.yorc.experimental.consul.linux.ansible:2.2.0-SNAPSHOT
   - org.ystia.yorc.experimental.consul.pub:2.2.0-SNAPSHOT
 

--- a/org/ystia/nfs/pub/types.yaml
+++ b/org/ystia/nfs/pub/types.yaml
@@ -22,7 +22,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.1.1
+  - alien-extended-storage-types:2.2.0-SM6
 
 node_types:
   org.ystia.nfs.pub.nodes.NFSServer:

--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -27,7 +27,7 @@ imports:
 
 repositories:
   fastconnect_nexus:
-    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.1.1
+    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.2.0-SM6
     type: http
 
 topology_template:
@@ -121,7 +121,7 @@ topology_template:
             initiator: source
       artifacts:
         alien_dist:
-          file: alien4cloud-dist-2.1.1-dist.tar.gz
+          file: alien4cloud-dist-2.2.0-SM6-dist.tar.gz
           type: tosca.artifacts.File
           repository: fastconnect_nexus
     AnsibleRuntime:

--- a/org/ystia/topologies/a4c_yorc_basic_secured/types.yaml
+++ b/org/ystia/topologies/a4c_yorc_basic_secured/types.yaml
@@ -28,7 +28,7 @@ imports:
 
 repositories:
   fastconnect_nexus:
-    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.1.1
+    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.2.0-SM6
     type: http
 
 topology_template:
@@ -141,7 +141,7 @@ topology_template:
             initiator: source
       artifacts:
         alien_dist:
-          file: alien4cloud-dist-2.1.1-dist.tar.gz
+          file: alien4cloud-dist-2.2.0-SM6-dist.tar.gz
           type: tosca.artifacts.File
           repository: fastconnect_nexus
     AnsibleRuntime:

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.1.1
+  - alien-extended-storage-types:2.2.0-SM6
 
   - org.alien4cloud.java.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT

--- a/org/ystia/topologies/elk_ha/types.yml
+++ b/org/ystia/topologies/elk_ha/types.yml
@@ -14,7 +14,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.1.1
+  - alien-extended-storage-types:2.2.0-SM6
 
   - org.ystia.common:2.2.0-SNAPSHOT
   - org.ystia.java.pub:2.2.0-SNAPSHOT

--- a/org/ystia/topologies/jupyter/types.yml
+++ b/org/ystia/topologies/jupyter/types.yml
@@ -13,7 +13,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.1.1
+  - alien-extended-storage-types:2.2.0-SM6
   - org.ystia.common:2.2.0-SNAPSHOT
   - org.ystia.python.pub:2.2.0-SNAPSHOT
   - org.ystia.python.linux.bash:2.2.0-SNAPSHOT

--- a/org/ystia/topologies/rstudio/types.yml
+++ b/org/ystia/topologies/rstudio/types.yml
@@ -13,7 +13,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.1.1
+  - alien-extended-storage-types:2.2.0-SM6
   - org.ystia.common:2.2.0-SNAPSHOT
   - org.ystia.java.pub:2.2.0-SNAPSHOT
   - org.ystia.java.linux.bash:2.2.0-SNAPSHOT


### PR DESCRIPTION
## Description of the change
Updated imported built-in types such as docker-types or alien-extended-dtorag types to version 2.2.0-SM
Updated alien artifacts.

### How to verify it
Install an Alien 2.2.0-SM6 (http://10.197.135.244/starlings/alien4cloud/alien4cloud-premium-dist-2.2.0-SM6-dist.tar.gz) and replace alien4cloud-yorc-provider by alien4cloud-yorc-plugin from https://github.com/ystia/yorc-a4c-plugin/pull/127

Upload archives from Git repository https://github.com/ystia/forge.git, branch GH-124-upgrade-to-alien-2.2, archive folder org/ystia

### Description for the changelog

## Applicable Issues
