### PR TITLE
Added an SSL CA installer component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### NEW COMPONENTS
 
+* SSL SSL Root CA installer component ([GH-103](https://github.com/ystia/forge/issues/103))
 * SSL Certificates Generator component ([GH-78](https://github.com/ystia/forge/issues/78))
 * Deploy Docker containers in pure TOSCA ([GH-76](https://github.com/ystia/forge/issues/76))
 * Docker Registry ([GH-80](https://github.com/ystia/forge/issues/80))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### NEW COMPONENTS
 
-* SSL SSL Root CA installer component ([GH-103](https://github.com/ystia/forge/issues/103))
+* SSL Root CA installer component ([GH-103](https://github.com/ystia/forge/issues/103))
 * SSL Certificates Generator component ([GH-78](https://github.com/ystia/forge/issues/78))
 * Deploy Docker containers in pure TOSCA ([GH-76](https://github.com/ystia/forge/issues/76))
 * Docker Registry ([GH-80](https://github.com/ystia/forge/issues/80))

--- a/org/ystia/ssl/ansible-ssl-certificates/README.md
+++ b/org/ystia/ssl/ansible-ssl-certificates/README.md
@@ -1,6 +1,9 @@
 # Ansible SSL certificates generator
 
-This component allows to generate SSL certificates.
+This CSAR contains two components:
+
+* `org.ystia.ssl.ansible.certificates.nodes.SSLCertificateGenerator` allows to generate SSL certificates
+* `org.ystia.ssl.ansible.certificates.nodes.SSLRootCAInstaller` allows to install SSL Root Certificate Authorities to the system trust store
 
 ## Icons
 

--- a/org/ystia/ssl/ansible-ssl-certificates/playbooks/ca_installer/configure.yaml
+++ b/org/ystia/ssl/ansible-ssl-certificates/playbooks/ca_installer/configure.yaml
@@ -1,0 +1,46 @@
+#
+# Copyright 2019 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- name: Generate Certificates
+  hosts: all
+  strategy: free
+  become: true
+  vars:
+    certs: "{{ CA_CERTS | from_json }}"
+  tasks:
+    - name: compute install path Debian
+      set_fact:
+        install_path: /usr/local/share/ca-certificates
+        command: "update-ca-certificates"
+      when: ansible_facts['os_family'] == "Debian"
+
+    - name: compute install path RedHat
+      set_fact:
+        install_path: /etc/pki/ca-trust/source/anchors
+        command: "update-ca-trust force-enable && update-ca-trust extract"
+      when: ansible_facts['os_family'] == "RedHat"
+
+    - name: copy certificates
+      copy:
+        dest: "{{ install_path }}/ssl-ca-installer-{{ idx }}.crt"
+        content: "{{ item }}"
+      loop: "{{ certs }}"
+      loop_control:
+        index_var: idx
+
+    - name: Update CA Trust
+      command: "{{ command }}"
+

--- a/org/ystia/ssl/ansible-ssl-certificates/types.yml
+++ b/org/ystia/ssl/ansible-ssl-certificates/types.yml
@@ -35,25 +35,25 @@ node_types:
       linux_owner:
         type: string
         description: >
-          Linux user that should be the owner of the certificates and keys. This user should have rights to write on 
+          Linux user that should be the owner of the certificates and keys. This user should have rights to write on
           certificate_path and key_path. By default it is the user used to connect to the machine.
         required: false
         default: ""
-      key_name: 
+      key_name:
         type: string
         required: false
         description: Name including extention of the private key file. By default it will be the node template within the topology + '.key'
-        default: "" 
-      certificate_name: 
+        default: ""
+      certificate_name:
         type: string
         required: false
         description: Name including extention of the certificate file. By default it will be the node template within the topology + '.pem'
-        default: "" 
-      private_key: 
+        default: ""
+      private_key:
         type: string
         required: false
         description: Content of a private key to use to generate the certificate
-        default: "" 
+        default: ""
       extra_sub_alt_name:
         type: string
         required: false
@@ -111,3 +111,22 @@ node_types:
             CERTIFICATE_PATH: { get_property: [SELF, certificate_path] }
             GEN_CERT_BECOME_USER: { get_property: [SELF, linux_owner] }
           implementation: playbooks/delete.yml
+
+
+  org.ystia.ssl.ansible.certificates.nodes.SSLRootCAInstaller:
+    derived_from: tosca.nodes.SoftwareComponent
+    metadata:
+      icon: /icons/ssl-certificate.png
+    properties:
+      certificate_authorities:
+        type: list
+        entry_schema:
+          type: string
+        description: Additional Root CA certificates to install, it should be the PEM-encoded certificate content.
+        required: true
+    interfaces:
+      Standard:
+        configure:
+          inputs:
+            CA_CERTS: { get_property: [SELF, certificate_authorities] }
+          implementation: playbooks/ca_installer/configure.yaml


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Added a new component within `org.ystia.ansible.ssl.certificates` CSAR named `org.ystia.ssl.ansible.certificates.nodes.SSLRootCAInstaller`

### Description for the changelog

* SSL Root CA installer component ([GH-103](https://github.com/ystia/forge/issues/103))

## Applicable Issues

Closes #103
