### PR TITLE
Feature/gh 109 openstack keystone v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### ENHANCEMENTS
 
+* Should support OpenStack Identity API v3 properties ([GH-109](https://github.com/ystia/forge/issues/109))
 * Support of locations ([GH-106](https://github.com/ystia/forge/issues/106))
 * Update forge components installing/configuring Yorc to support python3 ([GH-85](https://github.com/ystia/forge/issues/85))
 * Update Ansible version to 2.7.9 ([GH-83](https://github.com/ystia/forge/issues/83))

--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -34,8 +34,20 @@ topology_template:
   inputs:
     os_tenant_name:
       type: string
-      required: true
-      description: "The OpenStack tenant name to use."
+      required: false
+      description: "The OpenStack tenant name to use (Identity v2)"
+    os_project_name:
+      type: string
+      required: false
+      description: "The OpenStack project name to use (Identity v3)"
+    os_project_id:
+      type: string
+      required: false
+      description: "The OpenStack project ID to use (Identity v3)"
+    os_user_domain_name:
+      type: string
+      required: false
+      description: "The OpenStack domain name where the user is located (Identity v3)"
     os_password:
       type: string
       required: true
@@ -256,6 +268,9 @@ topology_template:
       properties:
         auth_url: { get_input: os_auth_url }
         tenant_name: { get_input: os_tenant_name }
+        project_name: { get_input: os_project_name }
+        project_id: { get_input: os_project_id }
+        user_domain_name: { get_input: os_user_domain_name }
         user_name: { get_input: os_user_name }
         password: { get_input: os_password }
         private_network_name: { get_input: os_private_network_name }

--- a/org/ystia/topologies/a4c_yorc_basic_secured/types.yaml
+++ b/org/ystia/topologies/a4c_yorc_basic_secured/types.yaml
@@ -35,8 +35,20 @@ topology_template:
   inputs:
     os_tenant_name:
       type: string
-      required: true
-      description: "The OpenStack tenant name to use."
+      required: false
+      description: "The OpenStack tenant name to use (Identity v2)"
+    os_project_name:
+      type: string
+      required: false
+      description: "The OpenStack project name to use (Identity v3)"
+    os_project_id:
+      type: string
+      required: false
+      description: "The OpenStack project ID to use (Identity v3)"
+    os_user_domain_name:
+      type: string
+      required: false
+      description: "The OpenStack domain name where the user is located (Identity v3)"
     os_password:
       type: string
       required: true
@@ -314,6 +326,9 @@ topology_template:
       properties:
         auth_url: { get_input: os_auth_url }
         tenant_name: { get_input: os_tenant_name }
+        project_name: { get_input: os_project_name }
+        project_id: { get_input: os_project_id }
+        user_domain_name: { get_input: os_user_domain_name }
         user_name: { get_input: os_user_name }
         password: { get_input: os_password }
         private_network_name: { get_input: os_private_network_name }

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -43,8 +43,20 @@ topology_template:
   inputs:
     os_tenant_name:
       type: string
-      required: true
-      description: "The OpenStack tenant name to use."
+      required: false
+      description: "The OpenStack tenant name to use (Identity v2)"
+    os_project_name:
+      type: string
+      required: false
+      description: "The OpenStack project name to use (Identity v3)"
+    os_project_id:
+      type: string
+      required: false
+      description: "The OpenStack project ID to use (Identity v3)"
+    os_user_domain_name:
+      type: string
+      required: false
+      description: "The OpenStack domain name where the user is located (Identity v3)"
     os_password:
       type: string
       required: true
@@ -297,6 +309,9 @@ topology_template:
       properties:
         auth_url: { get_input: os_auth_url }
         tenant_name: { get_input: os_tenant_name }
+        project_name: { get_input: os_project_name }
+        project_id: { get_input: os_project_id }
+        user_domain_name: { get_input: os_user_domain_name }
         user_name: { get_input: os_user_name }
         password: { get_input: os_password }
         private_network_name: { get_input: os_private_network_name }

--- a/org/ystia/yorc/README.rst
+++ b/org/ystia/yorc/README.rst
@@ -92,7 +92,13 @@ Properties
 
 - **password** : The OpenStack password to use.
 
-- **tenant_name** : The OpenStack tenant name to use.
+- **tenant_name** : The OpenStack tenant name to use (Identity v2).
+
+- **project_name** : The OpenStack project name to use (Identity v3).
+
+- **project_id** : The OpenStack project ID to use (Identity v3)
+
+- **user_domain_name** : The OpenStack domain name where the user is located (Identity v3).
 
 - **private_network_name** : The name of private network to use as primary adminstration network between Yorc and Compute instances. It should be a private network accessible by this instance of Yorc.
 

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_openstack.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_openstack.yml
@@ -63,6 +63,20 @@
             "private_network_name": "{{ PRIVATE_NETWORK_NAME }}",
             "provisioning_over_fip_allowed": "{{ PROVISIONING_OVER_FIP_ALLOWED | bool }}"
           }
+      when: TENANT_NAME != ''
+
+    - set_fact:
+        locationProperties: >
+          { "auth_url": "{{ AUTH_URL }}",
+            "project_name": "OPENSTACK_PROJECT_NAME_YORC_SUBSTITUTION",
+            "project_id": "OPENSTACK_PROJECT_ID_YORC_SUBSTITUTION",
+            "user_domain_name": "OPENSTACK_USER_DOMAIN_NAME_YORC_SUBSTITUTION",
+            "user_name": "OPENSTACK_USER_NAME_YORC_SUBSTITUTION",
+            "password": "OPENSTACK_PASSWORD_YORC_SUBSTITUTION",
+            "private_network_name": "{{ PRIVATE_NETWORK_NAME }}",
+            "provisioning_over_fip_allowed": "{{ PROVISIONING_OVER_FIP_ALLOWED | bool }}"
+          }
+      when: TENANT_NAME == ''
 
     - set_fact:
         tmp: >
@@ -104,18 +118,61 @@
         replace: "{{ USER_NAME }}"
       when: USE_VAULT == "false"
 
-    - name: Set OpenStack secret tenant name
+    - name: Set OpenStack secret tenant name (Identity v2)
       replace:
         path: "{{ CONFIG_DIR }}/locations.yorc.yaml"
         regexp: 'OPENSTACK_TENANT_NAME_YORC_SUBSTITUTION'
         replace: "'{{ '{{' }} secret \"/secret/yorc/locations/{{ LOCATION_NAME }}\" \"data=tenant_name\" | print {{ '}}' }}'"
-      when: USE_VAULT == "true"
-    - name: Set OpenStack tenant name
+      when: USE_VAULT == "true" and TENANT_NAME != ''
+
+    - name: Set OpenStack tenant name (Identity v2)
       replace:
         path: "{{ CONFIG_DIR }}/locations.yorc.yaml"
         regexp: 'OPENSTACK_TENANT_NAME_YORC_SUBSTITUTION'
         replace: "{{ TENANT_NAME }}"
-      when: USE_VAULT == "false"
+      when: USE_VAULT == "false" and TENANT_NAME != ''
+
+    - name: Set OpenStack secret project name (Identity v3)
+      replace:
+        path: "{{ CONFIG_DIR }}/locations.yorc.yaml"
+        regexp: 'OPENSTACK_PROJECT_NAME_YORC_SUBSTITUTION'
+        replace: "'{{ '{{' }} secret \"/secret/yorc/locations/{{ LOCATION_NAME }}\" \"data=project_name\" | print {{ '}}' }}'"
+      when: USE_VAULT == "true" and TENANT_NAME == ''
+
+    - name: Set OpenStack project name (Identity v3)
+      replace:
+        path: "{{ CONFIG_DIR }}/locations.yorc.yaml"
+        regexp: 'OPENSTACK_PROJECT_NAME_YORC_SUBSTITUTION'
+        replace: "{{ PROJECT_NAME }}"
+      when: USE_VAULT == "false" and TENANT_NAME == ''
+
+    - name: Set OpenStack secret project ID (Identity v3)
+      replace:
+        path: "{{ CONFIG_DIR }}/locations.yorc.yaml"
+        regexp: 'OPENSTACK_PROJECT_ID_YORC_SUBSTITUTION'
+        replace: "'{{ '{{' }} secret \"/secret/yorc/locations/{{ LOCATION_NAME }}\" \"data=project_id\" | print {{ '}}' }}'"
+      when: USE_VAULT == "true" and TENANT_NAME == ''
+
+    - name: Set OpenStack project ID (Identity v3)
+      replace:
+        path: "{{ CONFIG_DIR }}/locations.yorc.yaml"
+        regexp: 'OPENSTACK_PROJECT_ID_YORC_SUBSTITUTION'
+        replace: "{{ PROJECT_ID }}"
+      when: USE_VAULT == "false" and TENANT_NAME == ''
+
+    - name: Set OpenStack secret user domain name (Identity v3)
+      replace:
+        path: "{{ CONFIG_DIR }}/locations.yorc.yaml"
+        regexp: 'OPENSTACK_USER_DOMAIN_NAME_YORC_SUBSTITUTION'
+        replace: "'{{ '{{' }} secret \"/secret/yorc/locations/{{ LOCATION_NAME }}\" \"data=user_domain_name\" | print {{ '}}' }}'"
+      when: USE_VAULT == "true" and TENANT_NAME == ''
+
+    - name: Set OpenStack user domain name (Identity v3)
+      replace:
+        path: "{{ CONFIG_DIR }}/locations.yorc.yaml"
+        regexp: 'OPENSTACK_USER_DOMAIN_NAME_YORC_SUBSTITUTION'
+        replace: "{{ USER_DOMAIN_NAME }}"
+      when: USE_VAULT == "false" and TENANT_NAME == ''
 
     - name: Set OpenStack secret password
       replace:

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_openstack_secrets.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_openstack_secrets.yml
@@ -45,6 +45,9 @@
         body:
           user_name: "{{ USER_NAME }}"
           tenant_name: "{{ TENANT_NAME }}"
+          project_name: "{{ PROJECT_NAME }}"
+          project_id: "{{ PROJECT_ID }}"
+          user_domain_name: "{{ USER_DOMAIN_NAME }}"
           password: "{{ PASSWORD }}"
         body_format: json
         status_code: 204

--- a/org/ystia/yorc/yorc/linux/ansible/types.yaml
+++ b/org/ystia/yorc/yorc/linux/ansible/types.yaml
@@ -243,6 +243,9 @@ relationship_types:
             LOCATION_NAME : { get_property: [SOURCE, location_name] }
             AUTH_URL: { get_property: [SOURCE, auth_url] }
             TENANT_NAME: { get_property: [SOURCE, tenant_name] }
+            PROJECT_NAME: { get_property: [SOURCE, project_name] }
+            PROJECT_ID: { get_property: [SOURCE, project_id] }
+            USER_DOMAIN_NAME: { get_property: [SOURCE, user_domain_name] }
             USER_NAME: { get_property: [SOURCE, user_name] }
             PASSWORD: { get_property: [SOURCE, password] }
             PRIVATE_NETWORK_NAME: { get_property: [SOURCE, private_network_name] }
@@ -265,6 +268,9 @@ relationship_types:
             LOCATION_NAME : { get_property: [SOURCE, location_name] }
             CONFIG_DIR: { get_property: [SOURCE, config_dir] }
             TENANT_NAME: { get_property: [SOURCE, tenant_name] }
+            PROJECT_NAME: { get_property: [SOURCE, project_name] }
+            PROJECT_ID: { get_property: [SOURCE, project_id] }
+            USER_DOMAIN_NAME: { get_property: [SOURCE, user_domain_name] }
             USER_NAME: { get_property: [SOURCE, user_name] }
             PASSWORD: { get_property: [SOURCE, password] }
           implementation: playbooks/configure_openstack_secrets.yml

--- a/org/ystia/yorc/yorc/pub/types.yaml
+++ b/org/ystia/yorc/yorc/pub/types.yaml
@@ -94,9 +94,21 @@ node_types:
         type: string
         required: true
       tenant_name:
-        description: "OpenStack tenant name"
+        description: "OpenStack tenant name (Identity v2)"
         type: string
-        required: true
+        required: false
+      project_name:
+        description: "OpenStack project name (Identity v3)"
+        type: string
+        required: false
+      project_id:
+        description: "OpenStack project ID (Identity v3)"
+        type: string
+        required: false
+      user_domain_name:
+        description: "OpenStack domain name where the user is located (Identity v3)"
+        type: string
+        required: false
       user_name:
         description: "OpenStack user name"
         type: string


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

In topologies: made the Identity v2 property **tenant_name** optional, added Identity v3 properties.

Updated components and scripts configuring a location and vault secrets, to configure either a tenant name or Identity v3 properties.

### How to verify it

Using a Yorc from pull request https://github.com/ystia/yorc/pull/577 which contains the modifications done here in its bootstrap resources zip,
*  Non-regression: bootstrap a setup on an OpenStack setup using Identity v2, using bootstrap configuration values for the OpenStack location specifying a tenant name.
*  New test: bootstrap a setup on an OpenStack using Identity v3,  using bootstrap configuration values for the OpenStack location NOT specifying a tenant name, but specifying a user domain name and project ID.

### Description for the changelog

Should support OpenStack Identity API v3 properties ([GH-109](https://github.com/ystia/forge/issues/109))

## Applicable Issues

Closes #109 