### PR TITLE
Add components and topology for a simple Yorc-A4C stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 * Docker Registry ([GH-80](https://github.com/ystia/forge/issues/80))
 * Expose Hybrid demo material ([GH-93](https://github.com/ystia/forge/issues/93))
 * Component for the Yorc plugin provided by Alien4cloud (the Yorc Provider) ([GH-101](https://github.com/ystia/forge/issues/101))
+* Docker container component for Alien4Cloud deployment ([GH-111](https://github.com/ystia/forge/issues/111))
+* Docker container component for Yorc&Consul deployment ([GH-111](https://github.com/ystia/forge/issues/111))
+
+### NEW TOPOLOGY TEMPLATES
+
+* Template allowing to deploy a simple Yorc+Alien4Cloud stack based on Docker components ([GH-111](https://github.com/ystia/forge/issues/111))
 
 ### ENHANCEMENTS
 

--- a/org/ystia/alien/docker/README.md
+++ b/org/ystia/alien/docker/README.md
@@ -1,17 +1,18 @@
-# Alien4Cloud Tosca component
+# Alien4Cloud Tosca Node Template
 
-This componenent allows to deploy an Alien4Cloud, lets call it **Target Alien (TA)**, using an Alin4Cloud called **Source Alien (SA)**.
+This TOSCA type allows to deploy an Alien4Cloud docker container.
 
-The Docker image of the TA should be available in dockerhub, or other Docker registry.
-The SA can use the Yorc Orchestrator to deploy the TA to a Container Orchestrator as Kubernetes.
+The docker image should be available in dockerhub, or other Docker registry.
+
+The deployment to Kubernetes can be done using Alien4Cloud and Yorc.
 
 ## About used versions
 
-1. docker-types:2.2.0-SM10                 The SA used to deploy the component has version 2.2.0-SM10
-2. file: alien4cloud/alien4cloud:2.2.0-SM9 The deployed TA will have version 2.2.0-SM9
+1. Used Alien version: 2.2.0-SM10 (docker-types:2.2.0-SM10)
+2. Deployed Alien version: 2.2.0-SM10 (file: alien4cloud/alien4cloud:2.2.0-SM10)
 
 ## Usage
 
 Check used versions, and if necessary modify them correspondingly to your needs.
-Create a zip file with the types.yaml and upload it to the SA's Catalog.
+Create a zip file with the types.yaml and upload it to the used Alien4Cloud's Catalog.
   

--- a/org/ystia/alien/docker/README.md
+++ b/org/ystia/alien/docker/README.md
@@ -1,0 +1,17 @@
+# Alien4Cloud Tosca component
+
+This componenent allows to deploy an Alien4Cloud, lets call it **Target Alien (TA)**, using an Alin4Cloud called **Source Alien (SA)**.
+
+The Docker image of the TA should be available in dockerhub, or other Docker registry.
+The SA can use the Yorc Orchestrator to deploy the TA to a Container Orchestrator as Kubernetes.
+
+## About used versions
+
+1. docker-types:2.2.0-SM10                 The SA used to deploy the component has version 2.2.0-SM10
+2. file: alien4cloud/alien4cloud:2.2.0-SM9 The deployed TA will have version 2.2.0-SM9
+
+## Usage
+
+Check used versions, and if necessary modify them correspondingly to your needs.
+Create a zip file with the types.yaml and upload it to the SA's Catalog.
+  

--- a/org/ystia/alien/docker/types.yaml
+++ b/org/ystia/alien/docker/types.yaml
@@ -1,0 +1,58 @@
+tosca_definitions_version: alien_dsl_2_0_0
+#
+# Copyright 2020 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+metadata:
+  template_name: org.ystia.alien.docker
+  template_version: 1.0.0-SNAPSHOT
+  template_author: yorc
+
+imports:
+  - tosca-normative-types:1.0.0-ALIEN20
+  - docker-types:2.2.0-SM10
+
+description: Alien4cloud server that can be deployed to K8S
+
+repositories:
+  docker:
+    url: https://hub.docker.com/
+    type: a4c_ignore
+
+node_types:
+  org.ystia.alien.docker.nodes.Alien:
+    derived_from: tosca.nodes.Container.Application.DockerContainer
+    capabilities:
+      alien_console:
+        type: org.ystia.alien.docker.capabilities.AlienUI
+    interfaces:
+      Standard:
+        create:
+          implementation:
+            file: alien4cloud/alien4cloud:2.2.0-SM9
+            repository: docker
+            type: tosca.artifacts.Deployment.Image.Container.Docker
+
+capability_types:
+  org.ystia.alien.docker.capabilities.AlienUI:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      docker_bridge_port_mapping:
+        type: integer
+        description: Port used to bridge to the container's endpoint.
+        default: 8088
+      port:
+        type: integer
+        default: 8088

--- a/org/ystia/alien/docker/types.yaml
+++ b/org/ystia/alien/docker/types.yaml
@@ -41,7 +41,7 @@ node_types:
       Standard:
         create:
           implementation:
-            file: alien4cloud/alien4cloud:2.2.0-SM9
+            file: alien4cloud/alien4cloud:2.2.0-SM10
             repository: docker
             type: tosca.artifacts.Deployment.Image.Container.Docker
 

--- a/org/ystia/docker/ansible/types.yml
+++ b/org/ystia/docker/ansible/types.yml
@@ -14,7 +14,7 @@ metadata:
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - docker-types:2.2.0-SM6
+  - docker-types:2.2.0-SM10
 
 node_types:
   org.ystia.docker.ansible.nodes.Docker:

--- a/org/ystia/docker/containers/generic/types.yml
+++ b/org/ystia/docker/containers/generic/types.yml
@@ -16,7 +16,7 @@ metadata:
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - docker-types:2.2.0-SM6
+  - docker-types:2.2.0-SM10
 
 node_types:
   org.ystia.docker.containers.docker.generic.nodes.GenricContainer:

--- a/org/ystia/docker/topologies/secured-docker-registry/types.yml
+++ b/org/ystia/docker/topologies/secured-docker-registry/types.yml
@@ -11,8 +11,8 @@ imports:
   - org.ystia.docker.containers.docker.generic:2.2.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.ssl.ansible.certificates:2.2.0-SNAPSHOT
-  - alien-extended-storage-types:2.2.0-SM6
-  - docker-types:2.2.0-SM6
+  - alien-extended-storage-types:2.2.0-SM10
+  - docker-types:2.2.0-SM10
   - org.ystia.docker.ansible:2.2.0-SNAPSHOT
   - org.ystia.docker.containers.docker.registry:2.2.0-SNAPSHOT
   - yorc-types:1.1.0

--- a/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
+++ b/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
@@ -25,7 +25,7 @@ description: "This topology illustrates how to setup block storage and partition
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0-SM6
+  - alien-extended-storage-types:2.2.0-SM10
   - org.ystia.yorc.experimental.consul.linux.ansible:2.2.0-SNAPSHOT
   - org.ystia.yorc.experimental.consul.pub:2.2.0-SNAPSHOT
 

--- a/org/ystia/nfs/pub/types.yaml
+++ b/org/ystia/nfs/pub/types.yaml
@@ -22,7 +22,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0-SM6
+  - alien-extended-storage-types:2.2.0-SM10
 
 node_types:
   org.ystia.nfs.pub.nodes.NFSServer:

--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -27,7 +27,7 @@ imports:
 
 repositories:
   fastconnect_nexus:
-    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.2.0-SM6
+    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.2.0-SM10
     type: http
 
 topology_template:
@@ -133,7 +133,7 @@ topology_template:
             initiator: source
       artifacts:
         alien_dist:
-          file: alien4cloud-dist-2.2.0-SM6-dist.tar.gz
+          file: alien4cloud-dist-2.2.0-SM10-dist.tar.gz
           type: tosca.artifacts.File
           repository: fastconnect_nexus
     AnsibleRuntime:

--- a/org/ystia/topologies/a4c_yorc_basic_secured/types.yaml
+++ b/org/ystia/topologies/a4c_yorc_basic_secured/types.yaml
@@ -28,7 +28,7 @@ imports:
 
 repositories:
   fastconnect_nexus:
-    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.2.0-SM6
+    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.2.0-SM10
     type: http
 
 topology_template:
@@ -153,7 +153,7 @@ topology_template:
             initiator: source
       artifacts:
         alien_dist:
-          file: alien4cloud-dist-2.2.0-SM6-dist.tar.gz
+          file: alien4cloud-dist-2.2.0-SM10-dist.tar.gz
           type: tosca.artifacts.File
           repository: fastconnect_nexus
     AnsibleRuntime:

--- a/org/ystia/topologies/a4c_yorc_docker_basic/README.md
+++ b/org/ystia/topologies/a4c_yorc_docker_basic/README.md
@@ -1,0 +1,99 @@
+# Simple Yorc stack application template
+
+Defines an application template that alows to deploy a Yorc Stack composed by Yorc&Consul + Alien4Cloud.
+The **A4C** used to deploy the application has version 2.2.0-SM10
+
+Application is composed by the following components that need to already be uploaded in the A4C catalog:
+- org.ystia.yorc.docker
+- org.ystia.alien.docker
+
+## Prerequisits
+
+An available Kubernetes cluster.
+A Namespace context set (otherwise the Yorc stack is deployed on the **default** namespace).
+A ConfigMap created using --from-file option equal to the path of a directory that contains the configuration files for the Yorc to be deployed.
+
+## Usage
+
+### Update A4C Catalog
+
+Check used versions in this template and in components types, and if necessary modify them correspondingly to your needs. 
+Create a zip file with the types.yaml and upload it to the A4C's Catalog.
+
+### Create an application using this template.
+
+### Deploy it to a K8S location configured within a Yorc orchestrator (YO).
+See below for K8S location configuration
+
+### Check workloads and services on K8S
+
+```
+$ kubectl get services
+
+alien-aliendeployment-service-786916228   LoadBalancer   10.3.241.199   35.240.85.70   8088:32564/TCP
+yorc-yorcdeployment-service--1179116320   NodePort       10.3.255.250   <none>         8800:32018/TCP,8500:30449/TCP
+
+```
+
+### Configure deployed components
+
+Currently a manual configuration is necessary at this step.
+
+Some informations are necessary to be get from K8S. 
+
+In order to connect to the deployed Alien4Cloud's GUI:
+* alien-aliendeployment-service name; here alien-aliendeployment-service-786916228
+* alien-aliendeployment-service Load balancer IP ; here 35.240.85.70
+* alien-aliendeployment-service alien-console port; here 8088
+The Alien4Cloud's GUI can be reached with http://<lb-ip>:<alien-console-ip>; here  http://35.240.85.70:8088
+
+In order to connect the Alien4Cloud to the deployed Yorc orchestrator:
+* yorc-yorcdeployment-service name; here yorc-yorcdeployment-service--1179116320
+* yorc-yorcdeployment-service ClusterIP (NodePort Cluster IP); here 10.3.255.250
+* yorc-yorcdeployment-service yorc-server port; here 8800
+The Yorc orchestrator's URL will be http://<cluster-ip>:<yorc-server-port> ; here http://10.3.255.250:8800
+
+Now follow the next steps:
+
+1. Connect to the deployed Alien Console : http://35.240.85.70:8088
+2. Create a Yorc orchestrator (Yorch) with Yorc URL http://10.3.255.250:8800
+3. Create and configure locations for Yorch. For example, create a K8S location (See below for K8S location configuration)
+
+```
+$ kubectl get pods
+
+yorcdeployment--1518504487-545fc74c94-f2pqs    1/1     Running
+
+$ kubectl exec -ti yorcdeployment--1518504487-545fc74c94-f2pqs -- yorc loc list
+$ kubectl exec -ti yorcdeployment--1518504487-545fc74c94-f2pqs -- yorc loc add --data '{"name": "locationk8S","type": "kubernetes","properties": {}}'
+
+```
+
+May check Consul K/V base using Port forwarding on consul-ui TargetPort from yorc-yorcdeployment-service--1179116320
+
+
+## A4C Administration config
+
+### Create usefull Meta-properties
+
+- K8S_NAMESPACE
+- YORC_LOCATION 
+
+### K8S location configuration
+
+#### On demand resources
+
+- org.alien4cloud.kubernetes.api.types.Deployment
+- org.alien4cloud.kubernetes.api.types.Container
+- org.alien4cloud.kubernetes.api.types.volume.ConfigMapSource -set spec.name to the ConfigMap created for Yorc config files
+- NodePort org.alien4cloud.kubernetes.api.types.Service - to be matched by Alien_AlienDeployment_Service
+- LoadBalancer org.alien4cloud.kubernetes.api.types.Service - to be matched by Yorc_YorcDeployment
+
+#### Meta-properties
+
+- K8S_NAMESPACE = namespace name to be used
+- YORC_LOCATION = the K8S location name configured in the YO
+
+## Known Issues
+
+Need to fix **targetPort** values in the exposed  Service Ports (change the generated string value by the port number)

--- a/org/ystia/topologies/a4c_yorc_docker_basic/README.md
+++ b/org/ystia/topologies/a4c_yorc_docker_basic/README.md
@@ -1,11 +1,7 @@
 # Simple Yorc stack application template
 
-Defines an application template that alows to deploy a Yorc Stack composed by Yorc&Consul + Alien4Cloud.
+Defines an application template that alows to deploy a Yorc stack composed by Yorc&Consul + Alien4Cloud.
 The **A4C** used to deploy the application has version 2.2.0-SM10
-
-Application is composed by the following components that need to already be uploaded in the A4C catalog:
-- org.ystia.yorc.docker
-- org.ystia.alien.docker
 
 ## Prerequisits
 

--- a/org/ystia/topologies/a4c_yorc_docker_basic/README.md
+++ b/org/ystia/topologies/a4c_yorc_docker_basic/README.md
@@ -45,14 +45,13 @@ The Alien4Cloud's GUI can be reached with http://<lb-ip>:<alien-console-ip>; her
 
 In order to connect the Alien4Cloud to the deployed Yorc orchestrator:
 * yorc-yorcdeployment-service name; here yorc-yorcdeployment-service--1179116320
-* yorc-yorcdeployment-service ClusterIP (NodePort Cluster IP); here 10.3.255.250
 * yorc-yorcdeployment-service yorc-server port; here 8800
-The Yorc orchestrator's URL will be http://<cluster-ip>:<yorc-server-port> ; here http://10.3.255.250:8800
+The Yorc orchestrator's URL will be http://<yorc-service-name>:<yorc-service-port> ; here http://yorc-yorcdeployment-service--1179116320:8800
 
 Now follow the next steps:
 
 1. Connect to the deployed Alien Console : http://35.240.85.70:8088
-2. Create a Yorc orchestrator (Yorch) with Yorc URL http://10.3.255.250:8800
+2. Create a Yorc orchestrator (Yorch) with Yorc URL http:// yorc-yorcdeployment-service--1179116320:8800
 3. Create and configure locations for Yorch. For example, create a K8S location (See below for K8S location configuration)
 
 ```

--- a/org/ystia/topologies/a4c_yorc_docker_basic/README.md
+++ b/org/ystia/topologies/a4c_yorc_docker_basic/README.md
@@ -41,7 +41,7 @@ In order to connect to the deployed Alien4Cloud's GUI:
 * alien-aliendeployment-service name; here alien-aliendeployment-service-786916228
 * alien-aliendeployment-service Load balancer IP ; here 35.240.85.70
 * alien-aliendeployment-service alien-console port; here 8088
-The Alien4Cloud's GUI can be reached with http://<lb-ip>:<alien-console-ip>; here  http://35.240.85.70:8088
+The Alien4Cloud's GUI can be reached with http://<lb-ip>:<alien-console-port>; here  http://35.240.85.70:8088
 
 In order to connect the Alien4Cloud to the deployed Yorc orchestrator:
 * yorc-yorcdeployment-service name; here yorc-yorcdeployment-service--1179116320

--- a/org/ystia/topologies/a4c_yorc_docker_basic/types.yaml
+++ b/org/ystia/topologies/a4c_yorc_docker_basic/types.yaml
@@ -5,7 +5,7 @@ metadata:
   template_version: 0.1.1-SNAPSHOT
   template_author: yorc-team
 
-description: "A yorc server with consul embedded and an A4C server"
+description: "A simple yorc server with consul embedded and an A4C server"
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20

--- a/org/ystia/topologies/a4c_yorc_docker_basic/types.yaml
+++ b/org/ystia/topologies/a4c_yorc_docker_basic/types.yaml
@@ -1,0 +1,75 @@
+tosca_definitions_version: alien_dsl_2_0_0
+
+metadata:
+  template_name: org.ystia.topologies.a4c_yorc_docker_basic
+  template_version: 0.1.1-SNAPSHOT
+  template_author: yorc-team
+
+description: "A yorc server with consul embedded and an A4C server"
+
+imports:
+  - tosca-normative-types:1.0.0-ALIEN20
+  - org.ystia.yorc.docker:1.0.0-SNAPSHOT
+  - org.ystia.alien.docker:1.0.0-SNAPSHOT
+  - docker-types:2.2.0-SM10
+
+topology_template:
+  node_templates:
+    YorcContainer:
+      type: org.alien4cloud.extended.container.types.ContainerRuntime
+      requirements:
+        - hostedOnDeploymentHost:
+            type_requirement: host
+            node: YorcDeployment
+            capability: tosca.capabilities.Container.Docker
+            relationship: tosca.relationships.HostedOn
+    AlienContainer:
+      type: org.alien4cloud.extended.container.types.ContainerRuntime
+      requirements:
+        - hostedOnDeploymentHost:
+            type_requirement: host
+            node: AlienDeployment
+            capability: tosca.capabilities.Container.Docker
+            relationship: tosca.relationships.HostedOn
+    Yorc:
+      type: org.ystia.yorc.docker.nodes.Yorc
+      properties:
+        cpu_share: 0.3
+      requirements:
+        - hostedOnContainerRuntimeContainer:
+            type_requirement: host
+            node: YorcContainer
+            capability: org.alien4cloud.extended.container.capabilities.ApplicationHost
+            relationship: org.alien4cloud.extended.container.relationships.HostedOnContainerRuntime
+    Alien:
+      type: org.ystia.alien.docker.nodes.Alien
+      properties:
+        cpu_share: 0.3
+      requirements:
+        - hostedOnContainerRuntimeContainer:
+            type_requirement: host
+            node: AlienContainer
+            capability: org.alien4cloud.extended.container.capabilities.ApplicationHost
+            relationship: org.alien4cloud.extended.container.relationships.HostedOnContainerRuntime
+    
+    YorcDeployment:
+      type: org.alien4cloud.extended.container.types.ContainerDeploymentUnit
+
+    AlienDeployment:
+      type: org.alien4cloud.extended.container.types.ContainerDeploymentUnit
+
+    ConfigVolume:
+      type: org.alien4cloud.nodes.DockerExtVolume
+      requirements:
+        - mountDockerVolumeYorcAttach:
+            type_requirement: attachment
+            node: Yorc
+            capability: org.alien4cloud.capabilities.DockerVolumeAttachment
+            relationship: org.alien4cloud.relationships.MountDockerVolume
+            properties:
+              container_path: "/etc/yorc"
+        - hostedOnContainerDeploymentHost:
+            type_requirement: host
+            node: YorcDeployment
+            capability: tosca.capabilities.Container.Docker
+            relationship: tosca.relationships.HostedOn

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -9,7 +9,7 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0-SM6
+  - alien-extended-storage-types:2.2.0-SM10
 
   - org.alien4cloud.java.pub:2.2.0-SNAPSHOT
   - org.alien4cloud.alien4cloud.pub:2.2.0-SNAPSHOT

--- a/org/ystia/topologies/elk_ha/types.yml
+++ b/org/ystia/topologies/elk_ha/types.yml
@@ -14,7 +14,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0-SM6
+  - alien-extended-storage-types:2.2.0-SM10
 
   - org.ystia.common:2.2.0-SNAPSHOT
   - org.ystia.java.pub:2.2.0-SNAPSHOT

--- a/org/ystia/topologies/jupyter/types.yml
+++ b/org/ystia/topologies/jupyter/types.yml
@@ -13,7 +13,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0-SM6
+  - alien-extended-storage-types:2.2.0-SM10
   - org.ystia.common:2.2.0-SNAPSHOT
   - org.ystia.python.pub:2.2.0-SNAPSHOT
   - org.ystia.python.linux.bash:2.2.0-SNAPSHOT

--- a/org/ystia/topologies/rstudio/types.yml
+++ b/org/ystia/topologies/rstudio/types.yml
@@ -13,7 +13,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0-SM6
+  - alien-extended-storage-types:2.2.0-SM10
   - org.ystia.common:2.2.0-SNAPSHOT
   - org.ystia.java.pub:2.2.0-SNAPSHOT
   - org.ystia.java.linux.bash:2.2.0-SNAPSHOT

--- a/org/ystia/yorc/yorc/docker/README.md
+++ b/org/ystia/yorc/yorc/docker/README.md
@@ -1,17 +1,18 @@
-# Yorc & Consul Tosca component
+# Yorc & Consul Tosca Node Template
 
-This componenent allows to deploy a Yorc Server with its embedded Consul using Alien4Cloud (A4C).
+This TOSCA type allows to deploy a docker container with Yorc orchestrator and its Consul backend.
 
 The Docker image of Yorc&Consul should be available in dockerhub, or other Docker registry.
-A4C can use the Yorc Orchestrator to deploy the Yorc&Consul to a Container Orchestrator such as Kubernetes.
+
+The deployment to Kubernetes can be done using Alien4Cloud and Yorc.
 
 ## About versions
 
-1. docker-types:2.2.0-SM10     The A4C used for deployment has version 2.2.0-SM10
-2. file: ystia/yorc            The deployed Yorc's version will be the last available in the docker registry
+1. Used Alien version: 2.2.0-SM10 (docker-types:2.2.0-SM10)
+2. Deployed Yorc version: last available in jfrog (file: ystia-docker.jfrog.io/ystia/yorc)
 
 ## Usage
 
 Check used versions, and if necessary modify them correspondingly to your needs. 
-Create a zip file with the types.yaml and upload it to the A4C's Catalog.
+Create a zip file with the types.yaml and upload it to the Alien4Cloud's Catalog.
   

--- a/org/ystia/yorc/yorc/docker/README.md
+++ b/org/ystia/yorc/yorc/docker/README.md
@@ -1,0 +1,17 @@
+# Yorc & Consul Tosca component
+
+This componenent allows to deploy a Yorc Server with its embedded Consul using Alien4Cloud (A4C).
+
+The Docker image of Yorc&Consul should be available in dockerhub, or other Docker registry.
+A4C can use the Yorc Orchestrator to deploy the Yorc&Consul to a Container Orchestrator such as Kubernetes.
+
+## About versions
+
+1. docker-types:2.2.0-SM10     The A4C used for deployment has version 2.2.0-SM10
+2. file: ystia/yorc            The deployed Yorc's version will be the last available in the docker registry
+
+## Usage
+
+Check used versions, and if necessary modify them correspondingly to your needs. 
+Create a zip file with the types.yaml and upload it to the A4C's Catalog.
+  

--- a/org/ystia/yorc/yorc/docker/types.yaml
+++ b/org/ystia/yorc/yorc/docker/types.yaml
@@ -1,0 +1,89 @@
+tosca_definitions_version: alien_dsl_2_0_0
+#
+# Copyright 2020 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+metadata:
+  template_name: org.ystia.yorc.docker
+  template_version: 1.0.0-SNAPSHOT
+  template_author: yorc
+
+imports:
+  - tosca-normative-types:1.0.0-ALIEN20
+  - docker-types:2.2.0-SM10
+
+description: Yorc&Consul Docker Component
+
+repositories:
+  docker:
+    url: https://hub.docker.com/
+    type: a4c_ignore
+
+node_types:
+  org.ystia.yorc.docker.nodes.Yorc:
+    derived_from: tosca.nodes.Container.Application.DockerContainer
+    capabilities:
+      consul_ui:
+        type: org.ystia.yorc.docker.capabilities.ConsulUI
+        description: Endpoint to acess consul UI
+      yorc_server:
+        type: org.ystia.yorc.docker.capabilities.YorcRestAPI
+        description: Endpoint to communicate with yorc API
+    properties:
+      yorc_debug:
+        description: Enable or not Yorc's log debuging
+        type: string
+        required: true
+        default: "NO_DEBUG"
+        constraints:
+        - valid_values: [ "DEBUG", "NO_DEBUG" ]
+      consul_ui:
+        description: Enable consul UI available on port 8500
+        type: boolean
+        required: true
+        default: true
+    interfaces:
+      Standard:
+        create:
+          inputs:
+            ENV_YORC_LOG: { get_property: [SELF, yorc_debug] }
+            ENV_CONSUL_ENV_ui: { get_property: [SELF, consul_ui] }
+            ENV_CONSUL_ENV_client_addr: '"0.0.0.0"'
+          implementation:
+            file: ystia-docker.jfrog.io/ystia/yorc
+            repository: docker
+            type: tosca.artifacts.Deployment.Image.Container.Docker
+
+capability_types:
+  org.ystia.yorc.docker.capabilities.ConsulUI:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      docker_bridge_port_mapping:
+        type: integer
+        description: Port used to bridge to the container's endpoint.
+        default: 8500
+      port:
+        type: integer
+        default: 8500
+  org.ystia.yorc.docker.capabilities.YorcRestAPI:
+    derived_from: tosca.capabilities.Endpoint
+    properties:
+      docker_bridge_port_mapping:
+        type: integer
+        description: Port used to bridge to the container's endpoint.
+        default: 8800
+      port:
+        type: integer
+        default: 8800


### PR DESCRIPTION
# Pull Request description
Provide TOSCA types to allow the deployment of a simple Yorc+Alien4Cloud stack on K8S.

The deployment is to be made using an already installed YORC+A4C stack, configured to allow deployments on K8S locations.

## Description of the change
Added TOSCA types to Ystia Forge to allow the deployment on K8S of a simple Yorc+Alien4Cloud stack based on Docker components

### What I did
Add node types corresponding to Alien4Cloud component, and Yorc&Consul component
Add a topology template composed with the above components

### How to verify it

#### Prerequisits
* A K8S cluster configured. A ConfigMap resource created containing the future Yorc configuration. Maybe a Namespace created.

* Kubernetes location types configured in both YORC and A4C. 

- YORC kubernetes location must allow connection to the K8S cluster
- A4C kubernetes location must contain on-demand resources having org.alien4cloud.kubernetes.api.types. In particular, 2 service type resources are necessary, a NodePort for Yorc&Consul component and a LoadBalancer for the Alien4Cloud component. Morover, a ConfigMap volume type configued with spec.name = K8S ConfigMap name

* Upload to A4C Catalog the following artifacts (suppose that A4C version is 2.2.0-SM10):
[alien.zip](https://github.com/ystia/forge/files/4237039/alien.zip)
[yorc.zip](https://github.com/ystia/forge/files/4237041/yorc.zip)
[a4c_yorc_docker_basic.zip](https://github.com/ystia/forge/files/4237043/a4c_yorc_docker_basic.zip)

#### Deploy application
Create an application using  a4c_yorc_docker_basic topology template.
Deploy it to the kubernetes location. Verify correct matching for services and volumes.
Application should be in status _Deployed_.

#### Do some checks for workloads and services on K8S

`$ kubectl get services`
`alien-aliendeployment-service-786916228   LoadBalancer   10.3.241.199   35.240.85.70   8088:32564/TCP`
`yorc-yorcdeployment-service--1179116320   NodePort       10.3.255.250   <none>         8800:32018/TCP,8500:30449/TCP`

Note that you can configure 

#### Configure application
Connect to the deployed Alien4Cloud service (Alien4Cloud GUI). 
Create a Yorc Orchestrator and with Yorc URL in driver configuration set to the Url of the deployed Yorc service (yorc-yorcdeployment-service--1179116320:8800).
Enable the created Orchestrator. It should pass to _Connected_ state.

#### Other checks
Connect to deployed Yorc and/or Consul and check that the locations configured for Yorc in the ConfigMap are correct.

`$ kubectl get pods`
`yorcdeployment--1518504487-545fc74c94-f2pqs    1/1     Running`

`$ kubectl exec -ti yorcdeployment--1518504487-545fc74c94-f2pqs -- yorc loc list`

May check Consul K/V base using Port forwarding on consul-ui TargetPort from yorc-yorcdeployment-service--1179116320

### Description for the changelog

## Applicable Issues
https://github.com/ystia/forge/issues/111