### PR TITLE
Feature/gh 121 deploy k8s yorc stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 * Add a vault in secured full stack topology ([GH-67](https://github.com/ystia/forge/issues/67))
 * Provide forge components/topology allowing to install a secured Yorc setup ([GH-37](https://github.com/ystia/forge/issues/37))
 * Allow to configure resources prefix for bootstrapped Yorc ([GH-399](https://github.com/ystia/yorc/issues/399))
+* Allow to configure Alien4Cloud docker conatainer when deployed within a Yorc stack ([GH-121](https://github.com/ystia/forge/issues/121))
 
 ### DEPENDENCIES
 

--- a/org/ystia/alien/docker/README.md
+++ b/org/ystia/alien/docker/README.md
@@ -1,6 +1,7 @@
 # Alien4Cloud Tosca Node Template
 
 This TOSCA type allows to deploy an Alien4Cloud docker container.
+The Alien4Cloud component requires connection to a Yorc component in order to create and configure a Yorc orchestrator.
 
 The docker image should be available in dockerhub, or other Docker registry.
 

--- a/org/ystia/alien/docker/types.yaml
+++ b/org/ystia/alien/docker/types.yaml
@@ -23,8 +23,9 @@ metadata:
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - docker-types:2.2.0-SM10
+  - org.ystia.yorc.docker:1.0.0-SNAPSHOT
 
-description: Alien4cloud server that can be deployed to K8S
+description: Alien4cloud container provided by Ystia to be deployed to K8S together with a Yorc container
 
 repositories:
   docker:
@@ -34,14 +35,22 @@ repositories:
 node_types:
   org.ystia.alien.docker.nodes.Alien:
     derived_from: tosca.nodes.Container.Application.DockerContainer
+    requirements:
+      - yorc_server:
+          capability: org.ystia.yorc.docker.capabilities.YorcRestAPI
+          relationship: tosca.relationships.ConnectsTo
+          occurrences: [1, 1]
     capabilities:
       alien_console:
         type: org.ystia.alien.docker.capabilities.AlienUI
     interfaces:
       Standard:
         create:
+          inputs:
+            ENV_YORC_HOST: { get_attribute: [TARGET, yorc_server, service_name] }
+            ENV_YORC_PORT: { get_attribute: [TARGET, yorc_server, port] }
           implementation:
-            file: alien4cloud/alien4cloud:2.2.0-SM10
+            file: ystia/alien4cloud
             repository: docker
             type: tosca.artifacts.Deployment.Image.Container.Docker
 

--- a/org/ystia/alien/docker/types.yaml
+++ b/org/ystia/alien/docker/types.yaml
@@ -35,6 +35,12 @@ repositories:
 node_types:
   org.ystia.alien.docker.nodes.Alien:
     derived_from: tosca.nodes.Container.Application.DockerContainer
+    properties:
+      nb_retry: 
+        description: number tentatives to connect to Yorc orchestrator
+        type: integer
+        required: false
+        default: 25
     requirements:
       - yorc_server:
           capability: org.ystia.yorc.docker.capabilities.YorcRestAPI
@@ -47,6 +53,7 @@ node_types:
       Standard:
         create:
           inputs:
+            ENV_NB_RETRY: { get_property: [SELF, nb_retry] }
             ENV_YORC_HOST: { get_attribute: [TARGET, yorc_server, service_name] }
             ENV_YORC_PORT: { get_attribute: [TARGET, yorc_server, port] }
           implementation:

--- a/org/ystia/topologies/a4c_yorc_docker_basic/README.md
+++ b/org/ystia/topologies/a4c_yorc_docker_basic/README.md
@@ -18,8 +18,7 @@ Create a zip file with the types.yaml and upload it to the A4C's Catalog.
 
 ### Create an application using this template.
 
-### Deploy it to a K8S location configured within a Yorc orchestrator (YO).
-See below for K8S location configuration
+### Deploy it to a kubernetes location
 
 ### Check workloads and services on K8S
 
@@ -31,28 +30,13 @@ yorc-yorcdeployment-service--1179116320   NodePort       10.3.255.250   <none>  
 
 ```
 
-### Configure deployed components
+### Application configuration
 
-Currently a manual configuration is necessary at this step.
+Connect to the deployed Alien Console : http://35.240.85.70:8088. 
+A Yorc orchestrator should be created with Yorc URL set to http:// yorc-yorcdeployment-service--1179116320:8800, and enabled.
+A K8S location should be created and configured with onDemand resources.
 
-Some informations are necessary to be get from K8S. 
-
-In order to connect to the deployed Alien4Cloud's GUI:
-* alien-aliendeployment-service name; here alien-aliendeployment-service-786916228
-* alien-aliendeployment-service Load balancer IP ; here 35.240.85.70
-* alien-aliendeployment-service alien-console port; here 8088
-The Alien4Cloud's GUI can be reached with http://<lb-ip>:<alien-console-port>; here  http://35.240.85.70:8088
-
-In order to connect the Alien4Cloud to the deployed Yorc orchestrator:
-* yorc-yorcdeployment-service name; here yorc-yorcdeployment-service--1179116320
-* yorc-yorcdeployment-service yorc-server port; here 8800
-The Yorc orchestrator's URL will be http://<yorc-service-name>:<yorc-service-port> ; here http://yorc-yorcdeployment-service--1179116320:8800
-
-Now follow the next steps:
-
-1. Connect to the deployed Alien Console : http://35.240.85.70:8088
-2. Create a Yorc orchestrator (Yorch) with Yorc URL http:// yorc-yorcdeployment-service--1179116320:8800
-3. Create and configure locations for Yorch. For example, create a K8S location (See below for K8S location configuration)
+The Yorc server should be running and configured with a K8S location.
 
 ```
 $ kubectl get pods
@@ -60,34 +44,11 @@ $ kubectl get pods
 yorcdeployment--1518504487-545fc74c94-f2pqs    1/1     Running
 
 $ kubectl exec -ti yorcdeployment--1518504487-545fc74c94-f2pqs -- yorc loc list
-$ kubectl exec -ti yorcdeployment--1518504487-545fc74c94-f2pqs -- yorc loc add --data '{"name": "locationk8S","type": "kubernetes","properties": {}}'
 
 ```
 
 May check Consul K/V base using Port forwarding on consul-ui TargetPort from yorc-yorcdeployment-service--1179116320
 
-
-## A4C Administration config
-
-### Create usefull Meta-properties
-
-- K8S_NAMESPACE
-- YORC_LOCATION 
-
-### K8S location configuration
-
-#### On demand resources
-
-- org.alien4cloud.kubernetes.api.types.Deployment
-- org.alien4cloud.kubernetes.api.types.Container
-- org.alien4cloud.kubernetes.api.types.volume.ConfigMapSource -set spec.name to the ConfigMap created for Yorc config files
-- NodePort org.alien4cloud.kubernetes.api.types.Service - to be matched by Alien_AlienDeployment_Service
-- LoadBalancer org.alien4cloud.kubernetes.api.types.Service - to be matched by Yorc_YorcDeployment
-
-#### Meta-properties
-
-- K8S_NAMESPACE = namespace name to be used
-- YORC_LOCATION = the K8S location name configured in the YO
 
 ## Known Issues
 

--- a/org/ystia/topologies/a4c_yorc_docker_basic/types.yaml
+++ b/org/ystia/topologies/a4c_yorc_docker_basic/types.yaml
@@ -46,6 +46,11 @@ topology_template:
       properties:
         cpu_share: 0.3
       requirements:
+        - connectsToYorcServer:
+            type_requirement: yorc_server
+            node: Yorc
+            capability: org.ystia.yorc.docker.capabilities.YorcRestAPI
+            relationship: tosca.relationships.ConnectsTo
         - hostedOnContainerRuntimeContainer:
             type_requirement: host
             node: AlienContainer

--- a/org/ystia/yorc/yorc/docker/types.yaml
+++ b/org/ystia/yorc/yorc/docker/types.yaml
@@ -87,3 +87,7 @@ capability_types:
       port:
         type: integer
         default: 8800
+      service_name:
+        type: string
+        description: The name of the endpoint exposed to some other service
+        default: Yorc_YorcDeployment_Service


### PR DESCRIPTION
# Pull Request description
This PR is an enhancement of https://github.com/ystia/forge/pull/114

The deployment is to be made using an already installed YORC+A4C stack, configured to allow deployments on K8S locations. The A4C must use enhanced K8S modifier : https://github.com/alien4cloud/alien4cloud-kubernetes-plugin/pull/17

## Description of the change
The TOSCA types allowing the deployment of a simple Yorc+Alien4Cloud stack on K8S were enhanced to allow the configuration of Alien4Cloud. This is due to a relationship between the Alien4Cloud component and the Yorc component.

Also, another Alien4Cloud container is used, which is provided by the Ystia project, and which enrich the original one provided by Alien4Cloud with scripts that create and configure a Yorc orchestrator after the component creation.

### What I did
Add a new property named 'service_name' to the Yorc node's YorcRestAPI endpoint capability.
The value of this property will be updated by the K8S plugin's modifier with the effective K8S service name to be created at deployment time. This is based on an enhancement of the K8S plugin : https://github.com/alien4cloud/alien4cloud-kubernetes-plugin/pull/17

Add a relationship to a YorcRestAPI endpoint capability in the Alien4Cloud component. 
Add input properties to the create operation allowing the Alien4Cloud component configuration. Use ENV_{INPUT_NAME} input properties that will result in an environment variables inside the container. The input properties values are set with the Yorc target's capability properties.

### How to verify it

#### Prerequisits
* A K8S cluster configured. A ConfigMap resource created containing the future Yorc configuration. Maybe a Namespace created. 

* Kubernetes location types configured in both YORC and A4C. 

- YORC kubernetes location must allow connection to the K8S cluster
- A4C kubernetes location must contain on-demand resources having org.alien4cloud.kubernetes.api.types. In particular, 2 service type resources are necessary, a NodePort for Yorc&Consul component and a LoadBalancer for the Alien4Cloud component. Morover, a ConfigMap volume type configued with spec.name = K8S ConfigMap name

* Upload to A4C Catalog the following artifacts (suppose that A4C version is 2.2.0-SM10):
[alien.zip](https://github.com/ystia/forge/files/4281909/alien.zip)
[yorc.zip](https://github.com/ystia/forge/files/4281911/yorc.zip)
[a4c_yorc_docker_basic.zip](https://github.com/ystia/forge/files/4281916/a4c_yorc_docker_basic.zip)

#### Deploy application
Create an application using  a4c_yorc_docker_basic topology template.
Deploy it to the kubernetes location. Verify correct matching for services and volumes.
Application should be in status _Deployed_.

#### Do some checks for workloads and services on K8S

`$ kubectl get services`
`alien-aliendeployment-service-786916228   LoadBalancer   10.3.241.199   35.240.85.70   8088:32564/TCP`
`yorc-yorcdeployment-service--1179116320   NodePort       10.3.255.250   <none>         8800:32018/TCP,8500:30449/TCP`

Note that you can configure 

#### Application configuration
Connect to the deployed Alien4Cloud service (Alien4Cloud GUI). 
A Yorc Orchestrator should be created with Yorc URL in driver configuration set to the Url of the deployed Yorc service (yorc-yorcdeployment-service--1179116320:8800).
The Yorc orchestrator should be enabled. It should pass to _Connected_ state.
A location for kubernetes infrastructure named K8S should be created and configured with On-demand resources having org.alien4cloud.kubernetes.api.types.

#### Other checks
Connect to deployed Yorc and/or Consul and check that the locations configured for Yorc in the ConfigMap are correct.

`$ kubectl get pods`
`yorcdeployment--1518504487-545fc74c94-f2pqs    1/1     Running`

`$ kubectl exec -ti yorcdeployment--1518504487-545fc74c94-f2pqs -- yorc loc list`

May check Consul K/V base using Port forwarding on consul-ui TargetPort from yorc-yorcdeployment-service--1179116320

### Description for the changelog

## Applicable Issues

Fixes #121