### PR TITLE
Feature/gh 124 container props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### ENHANCEMENTS
 
+* Add docker container properties workdir and user ([GH-124](https://github.com/ystia/forge/issues/124))
 * Update to Kubernetes v1.17 ([GH-117](https://github.com/ystia/forge/issues/117))
 * Update Traefik to v2.1 ([GH-115](https://github.com/ystia/forge/issues/115))
 * Should support OpenStack Identity API v3 properties ([GH-109](https://github.com/ystia/forge/issues/109))

--- a/org/ystia/docker/containers/generic/playbooks/docker_container_tasks.yaml
+++ b/org/ystia/docker/containers/generic/playbooks/docker_container_tasks.yaml
@@ -40,6 +40,8 @@
     memory_reservation: "{{MEM_SHARE}}"
     published_ports: "{{DOCKER_PUB_PORT}}"
     restart_policy: "{{RESTART_POLICY}}"
+    user: "{{ USER }}"
     volumes: "{{ DOCKER_VOLUMES }}"
     state: "{{ DOCKER_STATE }}"
+    working_dir: "{{ WORKDIR }}"
   register: docker_res

--- a/org/ystia/docker/containers/generic/types.yml
+++ b/org/ystia/docker/containers/generic/types.yml
@@ -74,6 +74,10 @@ node_types:
         constraints:
           - valid_values: ["no", "on-failure", "always", "unless-stopped"]
         default: "no"
+      user:
+        type: string
+        description: "Username or UID (format: <name|uid>[:<group|gid>])"
+        required: false
       volumes:
         type: list
         entry_schema:
@@ -83,6 +87,10 @@ node_types:
           Use docker CLI-style syntax: /host:/container[:mode]
           You can specify a read mode for the mount with either ro or rw.
           SELinux hosts can additionally use z or Z to use a shared or private label for the volume.
+        required: false
+      workdir:
+        type: string
+        description: working directory inside the container
         required: false
     attributes:
       container_id: { get_operation_output: [SELF, Standard, create, CONTAINER_ID] }
@@ -103,7 +111,9 @@ node_types:
           MEM_SHARE_LIMIT: { get_property: [SELF, mem_share_limit] }
           PUBLISHED_PORTS: { get_property: [SELF, published_ports] }
           RESTART_POLICY: { get_property: [SELF, restart_policy] }
+          USER: { get_property: [SELF, user] }
           VOLUMES: { get_property: [SELF, volumes] }
+          WORKDIR: { get_property: [SELF, workdir] }
         create:
           implementation: playbooks/create.yaml
         start:


### PR DESCRIPTION
Added 2 docker container properties that can be needed in some contexts:

* **workdir**, to set the default working directory for running binaries within a container
* **user**, to set the default user within the container

Closes #124 