### PR TITLE
Fix pip installation failures for Consul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### BUG FIXES
 
-* Installation of Consul fails on recent Centos for GCP images ([GH-131](https://github.com/ystia/forge/issues/131))
+* Installation of Consul and Ansible fails on recent Centos for GCP images ([GH-131](https://github.com/ystia/forge/issues/131))
 
 ## 2.2.0 (April 17, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add docker container property to set the shared memory size ([GH-129](https://github.com/ystia/forge/issues/129))
 
+### BUG FIXES
+
+* Installation of Consul fails on recent Centos for GCP images ([GH-131](https://github.com/ystia/forge/issues/131))
+
 ## 2.2.0 (April 17, 2020)
 
 ### NEW COMPONENTS

--- a/org/ystia/ansible/linux/ansible/playbooks/create.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/create.yml
@@ -20,50 +20,47 @@
   become: true
   become_method: sudo
   tasks:
-    - name: Load a variable file based on the OS type, or a default if not found. Using free-form to specify the file.
+
+    - name: Get python version
+      # This will be deprecated in Ansible 2.9 in favor of python_requirements_info but
+      # it is not yet available in Ansible 2.7.9
+      python_requirements_facts:
+      register: pri
+      failed_when: "pri == None or pri.python_version == None or pri.python_version == ''"
+
+    - name: Load a variable file based on the OS type.
       include_vars:
         file: "{{ item }}"
       with_first_found:
-        - "vars/{{ ansible_distribution }}.yml"
-        - "vars/{{ ansible_os_family }}.yml"
+        - "vars/{{ ansible_os_family }}-py{{pri.python_version | replace('\n', '') | regex_replace('^(\\d+).*', '\\1') }}.yml"
+        - "vars/{{ ansible_os_family }}-py{{pri.python_version | replace('\n', '') | regex_replace('^(\\d+).*', '\\1') }}.yml"
 
-    - name: install prerequirements
-      package:
-        name: "{{item}}"
-        state: present
-      with_items: "{{install_packages}}"
-
-    - name: Check if distribution has easy_install or needs a pip3 installation
-      set_fact:
-        easy_install_available: "{{ ansible_distribution != 'Ubuntu' or ansible_distribution_major_version is version(18, '<') }}"
-
-    - name: Ensure pip is installed using easy_install when availabe
-      easy_install:
-        name: pip
-        state: latest
-      when: easy_install_available
-
-    - name: Install python3-pip when easy_install in not available
-      apt:
-        name:
-          - python3-pip
+    - name: RedHat - install prerequisites
+      yum:
+        name: "{{install_packages}}"
         state: present
         update_cache: yes
-      when: not easy_install_available
+      when: ansible_os_family == 'RedHat'
 
-    - name: install using pip
+
+    - name: Debian - install prerequisites
+      apt:
+        name: "{{ install_packages }}"
+        state: present
+        update_cache: yes
+      when: ansible_os_family == 'Debian'
+
+    - name: Install latest Pip version
+      pip:
+        name: "pip"
+        state: latest
+        executable: "{{pip_cmd}}"
+
+    - name: install Ansible using Pip
       pip:
         name:
           - "ansible=={{ANSIBLE_VERSION}}"
           - "jmespath==0.9.4"
           - "netaddr==0.7.19"
-      when: ANSIBLE_EXTRA_PACKAGE_REPOSITORY == ""
-
-    - name: install using pip package repository "{{ANSIBLE_EXTRA_PACKAGE_REPOSITORY}}"
-      pip:
-        name:
-          - "ansible=={{ANSIBLE_VERSION}}"
-          - "jmespath==0.9.4"
-          - "netaddr==0.7.19"
-        extra_args: --extra-index-url "{{ANSIBLE_EXTRA_PACKAGE_REPOSITORY}}"
-      when: ANSIBLE_EXTRA_PACKAGE_REPOSITORY != ""
+        executable: "{{pip_cmd}}"
+        extra_args: "{{ '--extra-index-url {}'.format(ANSIBLE_EXTRA_PACKAGE_REPOSITORY) if ANSIBLE_EXTRA_PACKAGE_REPOSITORY != ''}}"

--- a/org/ystia/ansible/linux/ansible/playbooks/vars/Debian-py2.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/vars/Debian-py2.yml
@@ -1,0 +1,24 @@
+#
+# Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+install_packages:
+  - gcc
+  - make
+  - python2
+  - python2-dev
+  - python-pip
+
+pip_cmd: "pip"

--- a/org/ystia/ansible/linux/ansible/playbooks/vars/Debian-py3.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/vars/Debian-py3.yml
@@ -17,6 +17,8 @@
 install_packages:
   - gcc
   - make
-  - python2
-  - python2-dev
-  - virtualenv
+  - python3
+  - python3-dev
+  - python3-pip
+
+pip_cmd: "pip3"

--- a/org/ystia/ansible/linux/ansible/playbooks/vars/RedHat-py2.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/vars/RedHat-py2.yml
@@ -1,0 +1,24 @@
+#
+# Copyright 2018 Bull S.A.S. Atos Technologies - Bull, Rue Jean Jaures, B.P.68, 78340, Les Clayes-sous-Bois, France.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+install_packages:
+  - gcc
+  - make
+  - python2
+  - python2-devel
+  - python-pip
+
+pip_cmd: "pip"

--- a/org/ystia/ansible/linux/ansible/playbooks/vars/RedHat-py3.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/vars/RedHat-py3.yml
@@ -17,6 +17,8 @@
 install_packages:
   - gcc
   - make
-  - python2
-  - python2-devel
-  - python-virtualenv
+  - python3
+  - python3-devel
+  - python3-pip
+
+pip_cmd: "pip3"

--- a/org/ystia/experimental/consul/linux/ansible/playbooks/consul_install.yaml
+++ b/org/ystia/experimental/consul/linux/ansible/playbooks/consul_install.yaml
@@ -39,7 +39,7 @@
       register: apt_res
       retries: 3
       until: apt_res is success
-      when: ansible_distribution == 'Ubuntu'
+      when: ansible_os_family == 'Debian'
 
     - name: Backup original resolve.conf
       copy:
@@ -60,11 +60,30 @@
         dnsmasq_conf_log: "DAEMON"
       when: INSTALL_DNSMASQ == "true"
 
+    - name: Get python version
+      # This will be deprecated in Ansible 2.9 in favor of python_requirements_info but
+      # it is not yet available in Ansible 2.7.9
+      python_requirements_facts:
+      register: pri
+      failed_when: "pri == None or pri.python_version == None or pri.python_version == ''"
+
+    - name: Set python version for pip
+      set_fact:
+        python_pip_pkg: "python3-pip"
+        pip_cmd: "pip3"
+
+    - name: Set python 2 version for pip
+      set_fact:
+        python_pip_pkg: "python-pip"
+        pip_cmd: "pip"
+      when: pri.python_version is version('3', '<')
+
     - name: RedHat - install prerequisites
       yum:
         name:
           - zip
           - unzip
+          - "{{ python_pip_pkg }}"
         state: present
         update_cache: yes
       when: ansible_os_family == 'RedHat'
@@ -74,9 +93,20 @@
         name:
           - zip
           - unzip
+          - "{{ python_pip_pkg }}"
         state: present
         update_cache: yes
       when: ansible_os_family == 'Debian'
+
+    - name: Install requirements
+      copy:
+        src: requirements.txt
+        dest: "{{ INSTALL_DIR }}"
+
+    - name: Install python requirements
+      pip:
+        requirements: "{{ INSTALL_DIR }}/requirements.txt"
+        executable: "{{pip_cmd}}"
 
     - name: create Consul group
       group: name=consul
@@ -124,7 +154,7 @@
         mode: "u=rx,g=rx,o=rx"
 
     - name: Install consul systemd unit
-      template: 
+      template:
         src: consul.service.j2
         dest: "/etc/systemd/system/consul.service"
         mode: "u=rw,g=rw,o=r"
@@ -137,34 +167,7 @@
         state: stopped
 
     - name: Install consul maintenance script
-      template: 
+      template:
         src: consul_maintenance.sh.j2
         dest: "{{INSTALL_DIR}}/consul_maintenance.sh"
         mode: "u=rwx,g=rx,o=rx"
-
-    - name: Check if distribution has easy_install or needs a pip3 installation
-      set_fact:
-        easy_install_available: "{{ ansible_distribution != 'Ubuntu' or ansible_distribution_major_version is version(18, '<') }}"
-
-    - name: Ensure pip is installed using easy_install when availabe
-      easy_install:
-        name: pip
-        state: latest
-      when: easy_install_available
-
-    - name: Install python3-pip when easy_install in not available
-      apt:
-        name:
-          - python3-pip
-        state: present
-        update_cache: yes
-      when: not easy_install_available
-
-    - name: Install requirements
-      copy:
-        src: requirements.txt
-        dest: "{{ INSTALL_DIR }}"
-
-    - name: Install python requirements
-      pip:
-        requirements: "{{ INSTALL_DIR }}/requirements.txt"

--- a/org/ystia/experimental/consul/linux/ansible/playbooks/consul_install.yaml
+++ b/org/ystia/experimental/consul/linux/ansible/playbooks/consul_install.yaml
@@ -98,7 +98,13 @@
         update_cache: yes
       when: ansible_os_family == 'Debian'
 
-    - name: Install requirements
+    - name: Install latest Pip version
+      pip:
+        name: "pip"
+        state: latest
+        executable: "{{pip_cmd}}"
+
+    - name: Copy python requirements
       copy:
         src: requirements.txt
         dest: "{{ INSTALL_DIR }}"


### PR DESCRIPTION
Fix Consul installation issue
Remove use of easy_install which is now deprecated
and not anymore installed per default on recent systems

# Pull Request description

## Description of the change

Python `easy_install` is deprecated in favor of `pip` and is not delivered by default anymore on most of distributions. Unfortunately we used `easy_install` to install `pip` itself. This change install `pip` using distributions package managers

### What I did

Stop using `easy_install` at all (do not even try to install it). Determine if we are running Python 2 or 3 and install the corresponding package.

### How to verify it

On GCP you can test to deploy a consul server with different OS
Note that Ubuntu 20.04 is not supported with Ansible 2.7.9 (opened ystia/yorc#648 to track it)

### Description for the changelog

* Installation of Consul fails on recent Centos for GCP images ([GH-131](https://github.com/ystia/forge/issues/131))

## Applicable Issues

Fixes #131 
