### PR TITLE
Switch to alien 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### DEPENDENCIES
+
+* Ystia Forge components require now Alien4Cloud 3.0.0
+
 ### ENHANCEMENTS
 
 * Add docker container property to set the shared memory size ([GH-129](https://github.com/ystia/forge/issues/129))

--- a/org/ystia/README.rst
+++ b/org/ystia/README.rst
@@ -133,7 +133,7 @@ For the second method:
 
   - Repository URL: https://github.com/alien4cloud/csar-public-library.git
   - Credentials: *none*
-  - Branch: **v2.2.0**
+  - Branch: **v3.0.x**
   - Archives to import:
 
     - **org/alien4cloud/consul**

--- a/org/ystia/alien/docker/README.md
+++ b/org/ystia/alien/docker/README.md
@@ -9,8 +9,8 @@ The deployment to Kubernetes can be done using Alien4Cloud and Yorc.
 
 ## About used versions
 
-1. Used Alien version: 2.2.0 (docker-types:2.2.0)
-2. Deployed Alien version: 2.2.0 (file: alien4cloud/alien4cloud:2.2.0)
+1. Used Alien version: 3.0.0 (docker-types:3.0.0)
+2. Deployed Alien version: 3.0.0 (file: alien4cloud/alien4cloud:3.0.0)
 
 ## Usage
 

--- a/org/ystia/alien/docker/types.yaml
+++ b/org/ystia/alien/docker/types.yaml
@@ -22,7 +22,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.2.0
+  - docker-types:3.0.0
   - org.ystia.yorc.docker:1.0.0-SNAPSHOT
 
 description: Alien4cloud container provided by Ystia to be deployed to K8S together with a Yorc container

--- a/org/ystia/ansible/linux/ansible/types.yaml
+++ b/org/ystia/ansible/linux/ansible/types.yaml
@@ -17,13 +17,13 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.ansible.linux.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: yorc
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.ansible.pub:2.3.0-SNAPSHOT
+  - org.ystia.ansible.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.ansible.linux.ansible.nodes.AnsibleRuntime:

--- a/org/ystia/ansible/pub/types.yaml
+++ b/org/ystia/ansible/pub/types.yaml
@@ -17,7 +17,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.ansible.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: yorc
 
 imports:

--- a/org/ystia/beats/linux/bash/types.yml
+++ b/org/ystia/beats/linux/bash/types.yml
@@ -8,16 +8,16 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.beats.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Beats are data shippers for many types of data you want to enrich with Logstash, search and analyze in Elasticsearch, and visualize in Kibana.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.logstash.pub:2.3.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.logstash.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.beats.linux.bash.nodes.Beat:

--- a/org/ystia/cloudera/linux/bash/types.yml
+++ b/org/ystia/cloudera/linux/bash/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.cloudera.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Cloudera big data distribution for Linux system
@@ -16,9 +16,9 @@ description: Cloudera big data distribution for Linux system
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.cloudera.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.cloudera.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.cloudera.linux.bash.nodes.ClouderaServer:

--- a/org/ystia/cloudera/pub/types.yml
+++ b/org/ystia/cloudera/pub/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.cloudera.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Cloudera support.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
 
 capability_types:
   org.ystia.cloudera.pub.capabilities.ClouderaServerEndpoint:

--- a/org/ystia/common/types.yml
+++ b/org/ystia/common/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.common
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: common part of all ystia components

--- a/org/ystia/consul/linux/bash/types.yml
+++ b/org/ystia/consul/linux/bash/types.yml
@@ -8,15 +8,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.consul.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Consul agent and server
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.consul.linux.bash.nodes.Consul:

--- a/org/ystia/consul/pub/types.yml
+++ b/org/ystia/consul/pub/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.consul.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Consul support.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.consul.pub.nodes.ConsulUser:

--- a/org/ystia/dns/dnsmasq/ansible/types.yml
+++ b/org/ystia/dns/dnsmasq/ansible/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.dns.dnsmasq.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.dns.pub:2.3.0-SNAPSHOT
+  - org.ystia.dns.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.dns.dnsmasq.ansible.nodes.Dnsmasq:

--- a/org/ystia/dns/pub/types.yml
+++ b/org/ystia/dns/pub/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.dns.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for DNS support.

--- a/org/ystia/dns/resolvconf/ansible/types.yml
+++ b/org/ystia/dns/resolvconf/ansible/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.dns.resolvconf.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.dns.pub:2.3.0-SNAPSHOT
+  - org.ystia.dns.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.dns.resolvconf.ansible.Resolvconf:
@@ -40,7 +40,7 @@ node_types:
         description: >
           Search list for host-name lookup (space-separated).
 
-          The search list is normally determined from the local domain name; by default, it contains only the local domain name. 
+          The search list is normally determined from the local domain name; by default, it contains only the local domain name.
           This may be changed by listing the desired domain search path following the search keyword with spaces or tabs separating
           the names. Resolver queries having fewer than ndots dots (default is 1) in them will be attempted using each component of
           the search path in turn until a match is found. For environments with multiple subdomains please read options ndots:n below
@@ -51,10 +51,10 @@ node_types:
     attributes:
       hostname: { get_operation_output: [SELF, Standard, configure, HOSTNAME] }
     requirements:
-      - dns_server: 
+      - dns_server:
           capability: org.ystia.dns.pub.capabilities.DnsEndpoint
           relationship: org.ystia.dns.resolvconf.ansible.relationships.ConnectsTo
-          occurrences: [1, UNBOUNDED] 
+          occurrences: [1, UNBOUNDED]
     interfaces:
       Standard:
         configure:
@@ -62,8 +62,8 @@ node_types:
             DOMAIN: { get_property: [SELF, domain]}
             SEARCH: { get_property: [SELF, search]}
           implementation: playbooks/configure.yaml
-          
-    
+
+
 relationship_types:
   org.ystia.dns.resolvconf.ansible.relationships.ConnectsTo:
     derived_from: tosca.relationships.ConnectsTo
@@ -83,4 +83,3 @@ relationship_types:
             HOSTNAME: {get_attribute: [SOURCE, hostname]}
             IP_ADDRESS: {get_attribute: [SOURCE, private_address]}
           implementation: playbooks/remove_host.yaml
-          

--- a/org/ystia/docker/ansible/types.yml
+++ b/org/ystia/docker/ansible/types.yml
@@ -14,7 +14,7 @@ metadata:
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - docker-types:2.2.0
+  - docker-types:3.0.0
 
 node_types:
   org.ystia.docker.ansible.nodes.Docker:

--- a/org/ystia/docker/ansible/types.yml
+++ b/org/ystia/docker/ansible/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.docker.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 imports:

--- a/org/ystia/docker/containers/docker-registry/types.yml
+++ b/org/ystia/docker/containers/docker-registry/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.docker.containers.docker.registry
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.docker.containers.docker.generic:2.3.0-SNAPSHOT
+  - org.ystia.docker.containers.docker.generic:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.docker.containers.docker.registry.nodes.Registry:

--- a/org/ystia/docker/containers/generic/types.yml
+++ b/org/ystia/docker/containers/generic/types.yml
@@ -16,7 +16,7 @@ metadata:
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - docker-types:2.2.0
+  - docker-types:3.0.0
 
 node_types:
   org.ystia.docker.containers.docker.generic.nodes.GenericContainer:

--- a/org/ystia/docker/containers/generic/types.yml
+++ b/org/ystia/docker/containers/generic/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.docker.containers.docker.generic
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 

--- a/org/ystia/docker/topologies/secured-docker-registry/types.yml
+++ b/org/ystia/docker/topologies/secured-docker-registry/types.yml
@@ -8,13 +8,13 @@ metadata:
 description: ""
 
 imports:
-  - org.ystia.docker.containers.docker.generic:2.3.0-SNAPSHOT
+  - org.ystia.docker.containers.docker.generic:3.0.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.ssl.ansible.certificates:2.3.0-SNAPSHOT
+  - org.ystia.ssl.ansible.certificates:3.0.0-SNAPSHOT
   - alien-extended-storage-types:2.2.0
   - docker-types:2.2.0
-  - org.ystia.docker.ansible:2.3.0-SNAPSHOT
-  - org.ystia.docker.containers.docker.registry:2.3.0-SNAPSHOT
+  - org.ystia.docker.ansible:3.0.0-SNAPSHOT
+  - org.ystia.docker.containers.docker.registry:3.0.0-SNAPSHOT
   - yorc-types:1.1.0
 
 topology_template:

--- a/org/ystia/docker/topologies/secured-docker-registry/types.yml
+++ b/org/ystia/docker/topologies/secured-docker-registry/types.yml
@@ -11,8 +11,8 @@ imports:
   - org.ystia.docker.containers.docker.generic:3.0.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.ssl.ansible.certificates:3.0.0-SNAPSHOT
-  - alien-extended-storage-types:2.2.0
-  - docker-types:2.2.0
+  - alien-extended-storage-types:3.0.0
+  - docker-types:3.0.0
   - org.ystia.docker.ansible:3.0.0-SNAPSHOT
   - org.ystia.docker.containers.docker.registry:3.0.0-SNAPSHOT
   - yorc-types:1.1.0

--- a/org/ystia/elasticsearch/linux/bash/types.yml
+++ b/org/ystia/elasticsearch/linux/bash/types.yml
@@ -8,17 +8,17 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.elasticsearch.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Elasticsearch implementation
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.elasticsearch.linux.bash.nodes.Elasticsearch:

--- a/org/ystia/elasticsearch/pub/types.yml
+++ b/org/ystia/elasticsearch/pub/types.yml
@@ -8,15 +8,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.elasticsearch.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Elasticsearch support.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.elasticsearch.pub.nodes.AbstractElasticSearch:
@@ -25,7 +25,7 @@ node_types:
     tags:
       icon: /images/elasticsearch-icon.png
     attributes:
-      api: 
+      api:
         type: string
     capabilities:
       search_resource: org.ystia.elasticsearch.pub.capabilities.SearchEndpoint

--- a/org/ystia/experimental/consul/linux/ansible/types.yaml
+++ b/org/ystia/experimental/consul/linux/ansible/types.yaml
@@ -18,13 +18,13 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.experimental.consul.linux.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: yorc
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
 
 description: >
   This component allows to deploy Consul with Ansible

--- a/org/ystia/experimental/consul/pub/types.yaml
+++ b/org/ystia/experimental/consul/pub/types.yaml
@@ -18,7 +18,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.experimental.consul.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: yorc
 
 imports:

--- a/org/ystia/experimental/consul/pub/types.yaml
+++ b/org/ystia/experimental/consul/pub/types.yaml
@@ -23,7 +23,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.alien4cloud.consul.pub:2.2.0
+  - org.alien4cloud.consul.pub:3.0.0-SNAPSHOT
 
 description: >
   This component exposes public interfaces for Consul

--- a/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
+++ b/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
@@ -25,7 +25,7 @@ description: "This topology illustrates how to setup block storage and partition
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0
+  - alien-extended-storage-types:3.0.0
   - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
   - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
 

--- a/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
+++ b/org/ystia/experimental/consul/topologies/ConsulOnBS/types.yaml
@@ -18,7 +18,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.experimental.consul.topologies.persistent
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: admin
 
 description: "This topology illustrates how to setup block storage and partitions in order to persist data (Consul Servers' data in this use case)"
@@ -26,8 +26,8 @@ description: "This topology illustrates how to setup block storage and partition
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - alien-extended-storage-types:2.2.0
-  - org.ystia.yorc.experimental.consul.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
 
 topology_template:
   node_templates:

--- a/org/ystia/experimental/consul/topologies/MultiDCWithWAN/types.yaml
+++ b/org/ystia/experimental/consul/topologies/MultiDCWithWAN/types.yaml
@@ -18,7 +18,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.experimental.consul.topologies.multiwan
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: admin
 
 description: >
@@ -27,8 +27,8 @@ description: >
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.yorc.experimental.consul.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
 
 topology_template:
   node_templates:

--- a/org/ystia/experimental/consul/topologies/SecuredClientServer/types.yaml
+++ b/org/ystia/experimental/consul/topologies/SecuredClientServer/types.yaml
@@ -18,15 +18,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.experimental.consul.topologies.secured
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: admin
 
 description: "A topology allowing to deploy secured Consul cluster"
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.yorc.experimental.consul.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
   - org.alien4cloud.consul.pub:2.2.0
   - yorc-types:1.1.0
 

--- a/org/ystia/experimental/consul/topologies/SecuredClientServer/types.yaml
+++ b/org/ystia/experimental/consul/topologies/SecuredClientServer/types.yaml
@@ -27,7 +27,7 @@ imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
   - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
-  - org.alien4cloud.consul.pub:2.2.0
+  - org.alien4cloud.consul.pub:3.0.0-SNAPSHOT
   - yorc-types:1.1.0
 
 topology_template:

--- a/org/ystia/experimental/consul/topologies/SimpleClientServer/types.yaml
+++ b/org/ystia/experimental/consul/topologies/SimpleClientServer/types.yaml
@@ -18,15 +18,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.experimental.consul.topologies.simple
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: admin
 
 description: "A simple topology used to demonstrate how to deploy a Consul cluster using Yorc"
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.yorc.experimental.consul.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
 
 topology_template:
   node_templates:

--- a/org/ystia/experimental/consul/topologies/consulClient/types.yaml
+++ b/org/ystia/experimental/consul/topologies/consulClient/types.yaml
@@ -18,15 +18,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.experimental.consul.topologies.client_template
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: admin
 
 description: "Consul Agent using the service exposed by a Consul Server"
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.yorc.experimental.consul.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
 
 topology_template:
   node_templates:

--- a/org/ystia/experimental/consul/topologies/consulService/types.yaml
+++ b/org/ystia/experimental/consul/topologies/consulService/types.yaml
@@ -17,15 +17,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.experimental.consul.topologies.service_template
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: admin
 
 description: "Consul Server exposing a service to Applications"
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.yorc.experimental.consul.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
 
 topology_template:
   # Other applications can reference the following Abstract Node Type

--- a/org/ystia/flink/linux/bash/types.yml
+++ b/org/ystia/flink/linux/bash/types.yml
@@ -8,17 +8,17 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.flink.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Apache Flink is an open source platform for distributed stream and batch data processing.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.flink.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.flink.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.flink.linux.bash.nodes.JobManager:

--- a/org/ystia/flink/pub/types.yml
+++ b/org/ystia/flink/pub/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.flink.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Flink support.

--- a/org/ystia/haproxy/linux/ansible/types.yml
+++ b/org/ystia/haproxy/linux/ansible/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.haproxy.linux.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: The HAProxy component ansible config
@@ -17,7 +17,7 @@ description: The HAProxy component ansible config
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.haproxy.pub:2.3.0-SNAPSHOT
+  - org.ystia.haproxy.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.haproxy.linux.ansible.nodes.HAProxy:

--- a/org/ystia/haproxy/linux/bash/types.yml
+++ b/org/ystia/haproxy/linux/bash/types.yml
@@ -8,15 +8,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.haproxy.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: The HAProxy component
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.haproxy.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.haproxy.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.haproxy.linux.bash.nodes.HAProxy:

--- a/org/ystia/haproxy/pub/types.yml
+++ b/org/ystia/haproxy/pub/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.haproxy.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for HA Proxy support.

--- a/org/ystia/java/linux/bash/types.yml
+++ b/org/ystia/java/linux/bash/types.yml
@@ -8,15 +8,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.java.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Allow to select a Java version to install on a system and to host other components requiring Java on top of it
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.java.linux.bash.nodes.Java:

--- a/org/ystia/java/pub/types.yml
+++ b/org/ystia/java/pub/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.java.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Java support.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
 
 # interfaces/Configure/pre_configure_source implementation must be in this public tosca to be able to get the JAVA_HOME value in the relationship target.
 relationship_types:

--- a/org/ystia/jupyter/linux/bash/types.yml
+++ b/org/ystia/jupyter/linux/bash/types.yml
@@ -8,16 +8,16 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.jupyter.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Jupyter notebook for linux system
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.python.pub:2.3.0-SNAPSHOT
-  - org.ystia.python.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.python.pub:3.0.0-SNAPSHOT
+  - org.ystia.python.linux.bash:3.0.0-SNAPSHOT
 
 
 node_types:

--- a/org/ystia/kafka/linux/bash/types.yml
+++ b/org/ystia/kafka/linux/bash/types.yml
@@ -8,17 +8,17 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.kafka.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Kafka is a distributed, partitioned, replicated commit log service.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.kafka.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.kafka.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.kafka.linux.bash.nodes.Kafka:
@@ -113,7 +113,7 @@ node_types:
           implementation:  scripts/kafka_start.sh
         stop:
           inputs:
-            KAFKA_HOME: { get_attribute: [SELF, kafka_home] }  
+            KAFKA_HOME: { get_attribute: [SELF, kafka_home] }
             JAVA_HOME: { get_attribute: [SELF, java_home] }
           implementation:  scripts/kafka_stop.sh
     artifacts:

--- a/org/ystia/kafka/pub/types.yml
+++ b/org/ystia/kafka/pub/types.yml
@@ -8,16 +8,16 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.kafka.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Kafka support.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
 
 capability_types:
   org.ystia.kafka.pub.capabilities.KafkaHosting:

--- a/org/ystia/kibana/linux/bash/types.yml
+++ b/org/ystia/kibana/linux/bash/types.yml
@@ -8,18 +8,18 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.kibana.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.kibana.linux.bash.nodes.Kibana:

--- a/org/ystia/kibana/pub/types.yml
+++ b/org/ystia/kibana/pub/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.kibana.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Kibana support.

--- a/org/ystia/kubernetes/linux/ansible/types.yml
+++ b/org/ystia/kubernetes/linux/ansible/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.kubernetes.linux.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: |
@@ -17,7 +17,7 @@ description: |
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.kubernetes.pub:2.3.0-SNAPSHOT
+  - org.ystia.kubernetes.pub:3.0.0-SNAPSHOT
 
 
 node_types:

--- a/org/ystia/kubernetes/pub/types.yml
+++ b/org/ystia/kubernetes/pub/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.kubernetes.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Kubernetes support.

--- a/org/ystia/kubernetes/topologies/kubernetes-yorc-cluster-ha/types.yml
+++ b/org/ystia/kubernetes/topologies/kubernetes-yorc-cluster-ha/types.yml
@@ -2,19 +2,19 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: Kubernetes-Yorc-Cluster-ha
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: admin
 
 description: "Setup an highly available Kubernetes Cluster plus some specific credentials to make it manageable by Yorc"
 
 imports:
   - yorc-types:1.1.0
-  - org.ystia.kubernetes.linux.ansible:2.3.0-SNAPSHOT
+  - org.ystia.kubernetes.linux.ansible:3.0.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.ssl.ansible.certificates:2.3.0-SNAPSHOT
-  - org.ystia.kubernetes.pub:2.3.0-SNAPSHOT
-  - org.ystia.haproxy.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.haproxy.pub:2.3.0-SNAPSHOT
+  - org.ystia.ssl.ansible.certificates:3.0.0-SNAPSHOT
+  - org.ystia.kubernetes.pub:3.0.0-SNAPSHOT
+  - org.ystia.haproxy.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.haproxy.pub:3.0.0-SNAPSHOT
 
 topology_template:
   inputs:

--- a/org/ystia/kubernetes/topologies/kubernetes-yorc-cluster/types.yml
+++ b/org/ystia/kubernetes/topologies/kubernetes-yorc-cluster/types.yml
@@ -2,15 +2,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: Kubernetes-Yorc-Cluster
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: admin
 
 description: "Setup a Kubernetes Cluster plus some specific credentials to make it manageable by Yorc"
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.kubernetes.pub:2.3.0-SNAPSHOT
-  - org.ystia.kubernetes.linux.ansible:2.3.0-SNAPSHOT
+  - org.ystia.kubernetes.pub:3.0.0-SNAPSHOT
+  - org.ystia.kubernetes.linux.ansible:3.0.0-SNAPSHOT
   - yorc-types:1.1.0
 
 topology_template:

--- a/org/ystia/logstash/linux/bash/types.yml
+++ b/org/ystia/logstash/linux/bash/types.yml
@@ -8,19 +8,19 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.logstash.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.kafka.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.logstash.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.kafka.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.logstash.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.logstash.linux.bash.nodes.Logstash:

--- a/org/ystia/logstash/pub/types.yml
+++ b/org/ystia/logstash/pub/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.logstash.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Logstash support.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
 
 capability_types:
   org.ystia.logstash.pub.capabilities.LogstashEndpoint:

--- a/org/ystia/mongodb/linux/ansible/types.yaml
+++ b/org/ystia/mongodb/linux/ansible/types.yaml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.mongodb.linux.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: MongoBD Component
@@ -16,8 +16,8 @@ description: MongoBD Component
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.mongodb.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.mongodb.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.mongodb.linux.ansible.nodes.MongoDB:

--- a/org/ystia/mongodb/pub/types.yml
+++ b/org/ystia/mongodb/pub/types.yml
@@ -8,16 +8,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.mongodb.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for MongoDB support.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
 
 capability_types:
   org.ystia.mongodb.pub.capabilities.Container.MongoDB:
     derived_from: tosca.capabilities.Container
-  

--- a/org/ystia/munge/ansible/types.yml
+++ b/org/ystia/munge/ansible/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.munge.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 

--- a/org/ystia/mysql/linux/bash/types.yml
+++ b/org/ystia/mysql/linux/bash/types.yml
@@ -8,15 +8,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.mysql.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: MySQL Component
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.mysql.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.mysql.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.mysql.linux.bash.nodes.MySQLServer:

--- a/org/ystia/mysql/pub/types.yml
+++ b/org/ystia/mysql/pub/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.mysql.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for MySql support.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
 
 capability_types:
   org.ystia.mysql.pub.capabilities.Container.MySQLServer:

--- a/org/ystia/nfs/linux/ansible/types.yaml
+++ b/org/ystia/nfs/linux/ansible/types.yaml
@@ -17,13 +17,13 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.nfs.linux.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: yorc
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.nfs.pub:2.3.0-SNAPSHOT
+  - org.ystia.nfs.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.nfs.linux.ansible.nodes.NFSServer:

--- a/org/ystia/nfs/pub/types.yaml
+++ b/org/ystia/nfs/pub/types.yaml
@@ -22,7 +22,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0
+  - alien-extended-storage-types:3.0.0
 
 node_types:
   org.ystia.nfs.pub.nodes.NFSServer:

--- a/org/ystia/nfs/pub/types.yaml
+++ b/org/ystia/nfs/pub/types.yaml
@@ -17,7 +17,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.nfs.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: yorc
 
 imports:

--- a/org/ystia/nifi/linux/bash/types.yml
+++ b/org/ystia/nifi/linux/bash/types.yml
@@ -8,16 +8,16 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.nifi.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: NiFi component implementation on Linux
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.nifi.linux.bash.nodes.NiFi:

--- a/org/ystia/ntp/ansible/types.yaml
+++ b/org/ystia/ntp/ansible/types.yaml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.ntp.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: ansible implementation for NTP support.
@@ -17,7 +17,7 @@ description: ansible implementation for NTP support.
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.ntp.pub:2.3.0-SNAPSHOT
+  - org.ystia.ntp.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.ntp.ansible.nodes.NtpServer:
@@ -37,10 +37,10 @@ node_types:
     metadata:
       icon: /images/ntp-client-icon.png
     requirements:
-      - ntp_server: 
+      - ntp_server:
           capability: org.ystia.ntp.pub.capabilities.NtpEndpoint
           relationship: org.ystia.ntp.ansible.relationships.ConnectsTo
-          occurrences: [1, UNBOUNDED] 
+          occurrences: [1, UNBOUNDED]
     interfaces:
       Standard:
         create: playbooks/create.yaml
@@ -50,8 +50,8 @@ node_types:
           implementation: playbooks/configure.yaml
         start: playbooks/start.yaml
         stop: playbooks/stop.yaml
-          
-    
+
+
 relationship_types:
   org.ystia.ntp.ansible.relationships.ConnectsTo:
     derived_from: tosca.relationships.ConnectsTo
@@ -61,4 +61,4 @@ relationship_types:
           IP_ADDRESS: {get_attribute: [TARGET, private_address]}
         add_target: playbooks/add_target_ntp_server.yaml
         remove_target: playbooks/remove_target_ntp_server.yaml
-          
+

--- a/org/ystia/ntp/pub/types.yaml
+++ b/org/ystia/ntp/pub/types.yaml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.ntp.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: pub implementation for NTP support.

--- a/org/ystia/python/linux/bash/types.yml
+++ b/org/ystia/python/linux/bash/types.yml
@@ -8,15 +8,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.python.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Anaconda-Python for linux system
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.python.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.python.pub:3.0.0-SNAPSHOT
 
 
 node_types:

--- a/org/ystia/python/pub/types.yml
+++ b/org/ystia/python/pub/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.python.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Python-Anaconda support.
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
 
 
 relationship_types:

--- a/org/ystia/rstudio/linux/bash/types.yml
+++ b/org/ystia/rstudio/linux/bash/types.yml
@@ -8,15 +8,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.rstudio.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: RStudio is a development platform for R through a web dashboard
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.rstudio.linux.bash.nodes.RStudio:

--- a/org/ystia/samples/apache-log-generator/types.yml
+++ b/org/ystia/samples/apache-log-generator/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.apache-log-generator.linux.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Ystia Fake apache log generator (from Github https://github.com/kiritbasu/Fake-Apache-Log-Generator)
@@ -16,9 +16,9 @@ description: Ystia Fake apache log generator (from Github https://github.com/kir
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+
 node_types:
   org.ystia.samples.apache-log-generator.linux.ansible.nodes.ApacheLogGeneratorDashboard:
     derived_from: org.ystia.kibana.linux.bash.nodes.KibanaDashboard

--- a/org/ystia/samples/dummylogs/linux/bash/types.yml
+++ b/org/ystia/samples/dummylogs/linux/bash/types.yml
@@ -8,17 +8,17 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.dummylogs.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Ystia DummyLogs Generator Sample
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+
 node_types:
   org.ystia.samples.dummylogs.linux.bash.nodes.DummyLogsDashboard:
     derived_from: org.ystia.kibana.linux.bash.nodes.KibanaDashboard

--- a/org/ystia/samples/hybrid-demo/cost-computing-dashboard/types.yaml
+++ b/org/ystia/samples/hybrid-demo/cost-computing-dashboard/types.yaml
@@ -18,15 +18,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.hybrid-demo.cost-computing-dashboard
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: ystia
 
 description: "Kibana Dashboard of Cost computing hybrid demo"
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
 
 node_types:
 

--- a/org/ystia/samples/hybrid-demo/cost-computing-job/types.yaml
+++ b/org/ystia/samples/hybrid-demo/cost-computing-job/types.yaml
@@ -18,7 +18,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.hybrid-demo.cost-computing-job
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: ystia
 
 description: "Singularity job to run Apache log generaetor cost computing job."
@@ -26,7 +26,7 @@ description: "Singularity job to run Apache log generaetor cost computing job."
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-slurm-types:2.2.0
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
 
 repositories:
   docker:

--- a/org/ystia/samples/hybrid-demo/cost-computing-job/types.yaml
+++ b/org/ystia/samples/hybrid-demo/cost-computing-job/types.yaml
@@ -25,7 +25,7 @@ description: "Singularity job to run Apache log generaetor cost computing job."
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - yorc-slurm-types:2.2.0
+  - yorc-slurm-types:3.0.0
   - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
 
 repositories:

--- a/org/ystia/samples/tcp-echo/ansible/types.yml
+++ b/org/ystia/samples/tcp-echo/ansible/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.tcpecho.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Ystia TCP Echo server sample

--- a/org/ystia/samples/topologies/apache-log-ref-compute-job/types.yaml
+++ b/org/ystia/samples/topologies/apache-log-ref-compute-job/types.yaml
@@ -12,7 +12,7 @@ imports:
 - org.ystia.java.pub:3.0.0-SNAPSHOT
 - org.ystia.samples.hybrid-demo.cost-computing-job:3.0.0-SNAPSHOT
 - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
-- yorc-slurm-types:2.2.0
+- yorc-slurm-types:3.0.0
 - org.ystia.kibana.pub:3.0.0-SNAPSHOT
 - org.ystia.common:3.0.0-SNAPSHOT
 - org.ystia.consul.pub:3.0.0-SNAPSHOT

--- a/org/ystia/samples/topologies/apache-log-ref-compute-job/types.yaml
+++ b/org/ystia/samples/topologies/apache-log-ref-compute-job/types.yaml
@@ -2,21 +2,21 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.ApacheLogsRefComputeJob
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: ystia
 
 description: "Topology that will compute the cost of our web server sponsored links."
 
 imports:
 - tosca-normative-types:1.0.0-ALIEN20
-- org.ystia.java.pub:2.2.0-SNAPSHOT
-- org.ystia.samples.hybrid-demo.cost-computing-job:2.2.0-SNAPSHOT
-- org.ystia.kibana.linux.bash:2.2.0-SNAPSHOT
+- org.ystia.java.pub:3.0.0-SNAPSHOT
+- org.ystia.samples.hybrid-demo.cost-computing-job:3.0.0-SNAPSHOT
+- org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
 - yorc-slurm-types:2.2.0
-- org.ystia.kibana.pub:2.2.0-SNAPSHOT
-- org.ystia.common:2.2.0-SNAPSHOT
-- org.ystia.consul.pub:2.2.0-SNAPSHOT
-- org.ystia.elasticsearch.pub:2.2.0-SNAPSHOT
+- org.ystia.kibana.pub:3.0.0-SNAPSHOT
+- org.ystia.common:3.0.0-SNAPSHOT
+- org.ystia.consul.pub:3.0.0-SNAPSHOT
+- org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
 - yorc-types:1.1.0
 
 topology_template:

--- a/org/ystia/samples/topologies/apache-logs-anonymization/types.yaml
+++ b/org/ystia/samples/topologies/apache-logs-anonymization/types.yaml
@@ -2,25 +2,25 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.ApacheGeneratorAnonymization
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: ystia
 
 description: ""
 
 imports:
-- org.ystia.kafka.pub:2.2.0-SNAPSHOT
+- org.ystia.kafka.pub:3.0.0-SNAPSHOT
 - tosca-normative-types:1.0.0-ALIEN20
-- org.ystia.beats.linux.bash:2.2.0-SNAPSHOT
-- org.ystia.samples.apache-log-generator.linux.ansible:2.2.0-SNAPSHOT
-- org.ystia.kibana.pub:2.2.0-SNAPSHOT
-- org.ystia.elasticsearch.pub:2.2.0-SNAPSHOT
-- org.ystia.java.linux.bash:2.2.0-SNAPSHOT
-- org.ystia.java.pub:2.2.0-SNAPSHOT
-- org.ystia.kibana.linux.bash:2.2.0-SNAPSHOT
-- org.ystia.logstash.pub:2.2.0-SNAPSHOT
-- org.ystia.logstash.linux.bash:2.2.0-SNAPSHOT
-- org.ystia.common:2.2.0-SNAPSHOT
-- org.ystia.consul.pub:2.2.0-SNAPSHOT
+- org.ystia.beats.linux.bash:3.0.0-SNAPSHOT
+- org.ystia.samples.apache-log-generator.linux.ansible:3.0.0-SNAPSHOT
+- org.ystia.kibana.pub:3.0.0-SNAPSHOT
+- org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+- org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+- org.ystia.java.pub:3.0.0-SNAPSHOT
+- org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+- org.ystia.logstash.pub:3.0.0-SNAPSHOT
+- org.ystia.logstash.linux.bash:3.0.0-SNAPSHOT
+- org.ystia.common:3.0.0-SNAPSHOT
+- org.ystia.consul.pub:3.0.0-SNAPSHOT
 - yorc-types:1.1.0
 
 topology_template:

--- a/org/ystia/samples/topologies/apache-logs-visu/types.yaml
+++ b/org/ystia/samples/topologies/apache-logs-visu/types.yaml
@@ -2,24 +2,24 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.ApacheGeneratorVisu
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: admin
 
 description: ""
 
 imports:
 - tosca-normative-types:1.0.0-ALIEN20
-- org.ystia.elasticsearch.linux.bash:2.2.0-SNAPSHOT
-- org.ystia.samples.apache-log-generator.linux.ansible:2.2.0-SNAPSHOT
-- org.ystia.kibana.pub:2.2.0-SNAPSHOT
-- org.ystia.elasticsearch.pub:2.2.0-SNAPSHOT
-- org.ystia.java.linux.bash:2.2.0-SNAPSHOT
-- org.ystia.java.pub:2.2.0-SNAPSHOT
-- org.ystia.samples.hybrid-demo.cost-computing-dashboard:2.2.0-SNAPSHOT
-- org.ystia.kibana.linux.bash:2.2.0-SNAPSHOT
+- org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+- org.ystia.samples.apache-log-generator.linux.ansible:3.0.0-SNAPSHOT
+- org.ystia.kibana.pub:3.0.0-SNAPSHOT
+- org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+- org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+- org.ystia.java.pub:3.0.0-SNAPSHOT
+- org.ystia.samples.hybrid-demo.cost-computing-dashboard:3.0.0-SNAPSHOT
+- org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
 - yorc-slurm-types:2.2.0
-- org.ystia.common:2.2.0-SNAPSHOT
-- org.ystia.consul.pub:2.2.0-SNAPSHOT
+- org.ystia.common:3.0.0-SNAPSHOT
+- org.ystia.consul.pub:3.0.0-SNAPSHOT
 - yorc-types:1.1.0
 
 topology_template:

--- a/org/ystia/samples/topologies/apache-logs-visu/types.yaml
+++ b/org/ystia/samples/topologies/apache-logs-visu/types.yaml
@@ -17,7 +17,7 @@ imports:
 - org.ystia.java.pub:3.0.0-SNAPSHOT
 - org.ystia.samples.hybrid-demo.cost-computing-dashboard:3.0.0-SNAPSHOT
 - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
-- yorc-slurm-types:2.2.0
+- yorc-slurm-types:3.0.0
 - org.ystia.common:3.0.0-SNAPSHOT
 - org.ystia.consul.pub:3.0.0-SNAPSHOT
 - yorc-types:1.1.0

--- a/org/ystia/samples/topologies/elk_apache_log_generator/types.yml
+++ b/org/ystia/samples/topologies/elk_apache_log_generator/types.yml
@@ -8,25 +8,25 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.elk_apache_generator
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.logstash.pub:2.3.0-SNAPSHOT
-  - org.ystia.logstash.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.beats.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.samples.apache-log-generator.linux.ansible:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.logstash.pub:3.0.0-SNAPSHOT
+  - org.ystia.logstash.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.beats.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.samples.apache-log-generator.linux.ansible:3.0.0-SNAPSHOT
 
 topology_template:
   description: A topology template to connect the Apache log generator sample to the ELK stack

--- a/org/ystia/samples/topologies/elk_beats/types.yml
+++ b/org/ystia/samples/topologies/elk_beats/types.yml
@@ -8,25 +8,25 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.elk_beats
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.logstash.pub:2.3.0-SNAPSHOT
-  - org.ystia.logstash.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.beats.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.samples.dummylogs.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.logstash.pub:3.0.0-SNAPSHOT
+  - org.ystia.logstash.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.beats.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.samples.dummylogs.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A topology template for Beats components with the Ystia DummyLogs sample connected to the ELK stack

--- a/org/ystia/samples/topologies/elk_dummylogs/types.yml
+++ b/org/ystia/samples/topologies/elk_dummylogs/types.yml
@@ -8,25 +8,25 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.elk_dummylogs
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.logstash.pub:2.3.0-SNAPSHOT
-  - org.ystia.logstash.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.beats.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.samples.dummylogs.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.logstash.pub:3.0.0-SNAPSHOT
+  - org.ystia.logstash.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.beats.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.samples.dummylogs.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A topology template to connect the Ystia DummyLogs sample to the ELK stack

--- a/org/ystia/samples/topologies/elk_heartbeat/types.yml
+++ b/org/ystia/samples/topologies/elk_heartbeat/types.yml
@@ -8,22 +8,22 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.elk_heartbeat
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.beats.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.beats.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A topology template for HeartBeat component with Elasticsearch and Kibana

--- a/org/ystia/samples/topologies/elk_nifi/types.yml
+++ b/org/ystia/samples/topologies/elk_nifi/types.yml
@@ -8,22 +8,22 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.elk_nifi
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.nifi.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.nifi.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A topology template to connect NiFi with Elasticsearch and Kibana

--- a/org/ystia/samples/topologies/elk_twitter/types.yml
+++ b/org/ystia/samples/topologies/elk_twitter/types.yml
@@ -8,23 +8,23 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.elk_twitter
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.logstash.pub:2.3.0-SNAPSHOT
-  - org.ystia.logstash.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.logstash.pub:3.0.0-SNAPSHOT
+  - org.ystia.logstash.linux.bash:3.0.0-SNAPSHOT
 
 
 topology_template:

--- a/org/ystia/samples/topologies/welcome_basic/types.yml
+++ b/org/ystia/samples/topologies/welcome_basic/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.welcome_basic
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.samples.welcome.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.samples.welcome.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A basic topology template for the Welcome sample

--- a/org/ystia/samples/topologies/welcome_monitoring/types.yml
+++ b/org/ystia/samples/topologies/welcome_monitoring/types.yml
@@ -8,16 +8,16 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.topologies.welcome_monitoring
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.samples.welcome.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.samples.tcpecho.ansible:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.samples.welcome.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.samples.tcpecho.ansible:3.0.0-SNAPSHOT
 
 topology_template:
   description: A monitored topology template for the Welcome sample

--- a/org/ystia/samples/welcome/linux/bash/types.yml
+++ b/org/ystia/samples/welcome/linux/bash/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.samples.welcome.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Ystia Welcome Web server sample
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.samples.welcome.linux.bash.nodes.Welcome:

--- a/org/ystia/slurm/ansible/types.yml
+++ b/org/ystia/slurm/ansible/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.slurm.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: public implementation for Slurm support.
@@ -17,16 +17,16 @@ description: public implementation for Slurm support.
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.slurm.pub:2.3.0-SNAPSHOT
+  - org.ystia.slurm.pub:3.0.0-SNAPSHOT
 
-node_types:    
+node_types:
   org.ystia.slurm.ansible.nodes.SlurmController:
     derived_from: org.ystia.slurm.pub.nodes.SlurmController
     attributes:
       hostname: { get_operation_output: [SELF, Standard, create, HOSTNAME] }
     interfaces:
       Standard:
-        create: 
+        create:
           inputs:
             DOWNLOAD_URL: {get_property: [SELF, download_url]}
           implementation: playbooks/create.yaml
@@ -38,7 +38,7 @@ node_types:
           implementation: playbooks/configure-ctld.yaml
         start: playbooks/start-ctld.yaml
         stop: playbooks/stop-ctld.yaml
-  
+
   org.ystia.slurm.ansible.nodes.SlurmDaemon:
     derived_from: org.ystia.slurm.pub.nodes.SlurmDaemon
     attributes:
@@ -49,7 +49,7 @@ node_types:
       real_memory: { get_operation_output: [SELF, Standard, configure, real_memory] }
     interfaces:
       Standard:
-        create: 
+        create:
           inputs:
             DOWNLOAD_URL: {get_property: [SELF, download_url]}
           implementation: playbooks/create.yaml
@@ -64,7 +64,7 @@ node_types:
       - slurmctl:
           capability: org.ystia.slurm.pub.capabilities.SlurmControllerEndpoint
           relationship: org.ystia.slurm.ansible.relationships.SlurmDaemonConnectsTo
-          occurrences: [1, 1] 
+          occurrences: [1, 1]
 
 relationship_types:
   org.ystia.slurm.ansible.relationships.SlurmDaemonConnectsTo:

--- a/org/ystia/slurm/pub/types.yml
+++ b/org/ystia/slurm/pub/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.slurm.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public implementation for Slurm support.
@@ -44,7 +44,7 @@ node_types:
           - min_length: 1
     capabilities:
       slurmctl_endpoint: org.ystia.slurm.pub.capabilities.SlurmControllerEndpoint
-  
+
   org.ystia.slurm.pub.nodes.SlurmDaemon:
     derived_from: org.ystia.slurm.pub.nodes.Slurm
     abstract: true
@@ -53,7 +53,7 @@ node_types:
     requirements:
       - slurmctl:
           capability: org.ystia.slurm.pub.capabilities.SlurmControllerEndpoint
-          occurrences: [1, 1] 
+          occurrences: [1, 1]
 
 
 capability_types:

--- a/org/ystia/ssl/ansible-ssl-certificates/types.yml
+++ b/org/ystia/ssl/ansible-ssl-certificates/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.ssl.ansible.certificates
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Generate Certificates using Ansible

--- a/org/ystia/terraform/linux/ansible/types.yaml
+++ b/org/ystia/terraform/linux/ansible/types.yaml
@@ -17,13 +17,13 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.terraform.linux.terraform
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: yorc
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.terraform.pub:2.3.0-SNAPSHOT
+  - org.ystia.terraform.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.terraform.linux.terraform.nodes.TerraformRuntime:

--- a/org/ystia/terraform/pub/types.yaml
+++ b/org/ystia/terraform/pub/types.yaml
@@ -17,7 +17,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.terraform.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: yorc
 
 imports:

--- a/org/ystia/tests/topologies/elk_elastic/types.yml
+++ b/org/ystia/tests/topologies/elk_elastic/types.yml
@@ -12,19 +12,19 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.tests.topologies.elk_elastic
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A basic topology template with Elasticsearch

--- a/org/ystia/tests/topologies/elk_kafka/types.yml
+++ b/org/ystia/tests/topologies/elk_kafka/types.yml
@@ -12,18 +12,18 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.tests.topologies.elk_kafka
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kafka.pub:2.3.0-SNAPSHOT
-  - org.ystia.kafka.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kafka.pub:3.0.0-SNAPSHOT
+  - org.ystia.kafka.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A basic topology template with Kafka

--- a/org/ystia/tests/topologies/elk_kibana/types.yml
+++ b/org/ystia/tests/topologies/elk_kibana/types.yml
@@ -12,21 +12,21 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.tests.topologies.elk_kibana
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
 
 
 topology_template:

--- a/org/ystia/tests/topologies/nifi/types.yml
+++ b/org/ystia/tests/topologies/nifi/types.yml
@@ -12,18 +12,18 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.tests.topologies.nifi
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.nifi.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.nifi.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A basic topology template with NiFi

--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -2,7 +2,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.a4c_yorc_basic
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: "Full stack setup on a single node"
@@ -12,16 +12,16 @@ imports:
   - org.alien4cloud.alien4cloud.pub:2.2.0
   - org.alien4cloud.alien4cloud.webapp:2.2.0
   - org.alien4cloud.java.jdk.linux:2.2.0
-  - org.ystia.terraform.linux.terraform:2.3.0-SNAPSHOT
-  - org.ystia.yorc.alien4cloud:2.3.0-SNAPSHOT
-  - org.ystia.ansible.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.terraform.pub:2.3.0-SNAPSHOT
-  - org.ystia.yorc.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.pub:2.3.0-SNAPSHOT
-  - org.ystia.ansible.pub:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.yorc.alien4cloud_yorc_provider:2.3.0-SNAPSHOT
+  - org.ystia.terraform.linux.terraform:3.0.0-SNAPSHOT
+  - org.ystia.yorc.alien4cloud:3.0.0-SNAPSHOT
+  - org.ystia.ansible.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.terraform.pub:3.0.0-SNAPSHOT
+  - org.ystia.yorc.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.pub:3.0.0-SNAPSHOT
+  - org.ystia.ansible.pub:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.yorc.alien4cloud_yorc_provider:3.0.0-SNAPSHOT
 
 
 repositories:

--- a/org/ystia/topologies/a4c_yorc_basic/types.yml
+++ b/org/ystia/topologies/a4c_yorc_basic/types.yml
@@ -9,9 +9,9 @@ description: "Full stack setup on a single node"
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.alien4cloud.alien4cloud.pub:2.2.0
-  - org.alien4cloud.alien4cloud.webapp:2.2.0
-  - org.alien4cloud.java.jdk.linux:2.2.0
+  - org.alien4cloud.alien4cloud.pub:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.webapp:3.0.0-SNAPSHOT
+  - org.alien4cloud.java.jdk.linux:3.0.0-SNAPSHOT
   - org.ystia.terraform.linux.terraform:3.0.0-SNAPSHOT
   - org.ystia.yorc.alien4cloud:3.0.0-SNAPSHOT
   - org.ystia.ansible.linux.ansible:3.0.0-SNAPSHOT
@@ -26,7 +26,7 @@ imports:
 
 repositories:
   fastconnect_nexus:
-    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.2.0
+    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/3.0.0-SNAPSHOT
     type: http
 
 topology_template:
@@ -132,7 +132,7 @@ topology_template:
             initiator: source
       artifacts:
         alien_dist:
-          file: alien4cloud-dist-2.2.0-dist.tar.gz
+          file: alien4cloud-dist-3.0.0-SNAPSHOT-dist.tar.gz
           type: tosca.artifacts.File
           repository: fastconnect_nexus
     AnsibleRuntime:

--- a/org/ystia/topologies/a4c_yorc_basic_secured/types.yaml
+++ b/org/ystia/topologies/a4c_yorc_basic_secured/types.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.a4c_yorc_basic_secured
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: "Full stack setup on a single node, secured"
@@ -14,16 +14,16 @@ imports:
   - org.alien4cloud.java.jdk.linux:2.2.0
   - org.alien4cloud.vault.pub:2.2.0
   - org.alien4cloud.vault.vault_sh:2.2.0
-  - org.ystia.terraform.linux.terraform:2.3.0-SNAPSHOT
-  - org.ystia.yorc.alien4cloud:2.3.0-SNAPSHOT
-  - org.ystia.ansible.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.terraform.pub:2.3.0-SNAPSHOT
-  - org.ystia.yorc.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.pub:2.3.0-SNAPSHOT
-  - org.ystia.ansible.pub:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.yorc.alien4cloud_yorc_provider:2.3.0-SNAPSHOT
+  - org.ystia.terraform.linux.terraform:3.0.0-SNAPSHOT
+  - org.ystia.yorc.alien4cloud:3.0.0-SNAPSHOT
+  - org.ystia.ansible.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.terraform.pub:3.0.0-SNAPSHOT
+  - org.ystia.yorc.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.pub:3.0.0-SNAPSHOT
+  - org.ystia.ansible.pub:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.yorc.alien4cloud_yorc_provider:3.0.0-SNAPSHOT
 
 
 repositories:

--- a/org/ystia/topologies/a4c_yorc_basic_secured/types.yaml
+++ b/org/ystia/topologies/a4c_yorc_basic_secured/types.yaml
@@ -9,11 +9,11 @@ description: "Full stack setup on a single node, secured"
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.alien4cloud.alien4cloud.pub:2.2.0
-  - org.alien4cloud.alien4cloud.webapp:2.2.0
-  - org.alien4cloud.java.jdk.linux:2.2.0
-  - org.alien4cloud.vault.pub:2.2.0
-  - org.alien4cloud.vault.vault_sh:2.2.0
+  - org.alien4cloud.alien4cloud.pub:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.webapp:3.0.0-SNAPSHOT
+  - org.alien4cloud.java.jdk.linux:3.0.0-SNAPSHOT
+  - org.alien4cloud.vault.pub:3.0.0-SNAPSHOT
+  - org.alien4cloud.vault.vault_sh:3.0.0-SNAPSHOT
   - org.ystia.terraform.linux.terraform:3.0.0-SNAPSHOT
   - org.ystia.yorc.alien4cloud:3.0.0-SNAPSHOT
   - org.ystia.ansible.linux.ansible:3.0.0-SNAPSHOT
@@ -28,7 +28,7 @@ imports:
 
 repositories:
   fastconnect_nexus:
-    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.2.0
+    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/3.0.0-SNAPSHOT
     type: http
 
 topology_template:
@@ -153,7 +153,7 @@ topology_template:
             initiator: source
       artifacts:
         alien_dist:
-          file: alien4cloud-dist-2.2.0-dist.tar.gz
+          file: alien4cloud-dist-3.0.0-SNAPSHOT-dist.tar.gz
           type: tosca.artifacts.File
           repository: fastconnect_nexus
     AnsibleRuntime:

--- a/org/ystia/topologies/a4c_yorc_docker_basic/README.md
+++ b/org/ystia/topologies/a4c_yorc_docker_basic/README.md
@@ -1,7 +1,7 @@
 # Simple Yorc stack application template
 
 Defines an application template that alows to deploy a Yorc stack composed by Yorc&Consul + Alien4Cloud.
-The **A4C** used to deploy the application has version 2.2.0
+The **A4C** used to deploy the application has version 3.0.0-SNAPSHOT
 
 ## Prerequisits
 

--- a/org/ystia/topologies/a4c_yorc_docker_basic/types.yaml
+++ b/org/ystia/topologies/a4c_yorc_docker_basic/types.yaml
@@ -11,7 +11,7 @@ imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.ystia.yorc.docker:1.0.0-SNAPSHOT
   - org.ystia.alien.docker:1.0.0-SNAPSHOT
-  - docker-types:2.2.0
+  - docker-types:3.0.0
 
 topology_template:
   node_templates:

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -9,12 +9,12 @@ description: ""
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0
-  - org.alien4cloud.java.pub:2.2.0
-  - org.alien4cloud.alien4cloud.pub:2.2.0
-  - org.alien4cloud.alien4cloud.webapp:2.2.0
-  - org.alien4cloud.java.jdk.linux:2.2.0
-  - org.alien4cloud.alien4cloud.config.pub:2.2.0
+  - alien-extended-storage-types:3.0.0
+  - org.alien4cloud.java.pub:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.pub:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.webapp:3.0.0-SNAPSHOT
+  - org.alien4cloud.java.jdk.linux:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.pub:3.0.0-SNAPSHOT
   - org.ystia.terraform.linux.terraform:3.0.0-SNAPSHOT
   - org.ystia.yorc.alien4cloud:3.0.0-SNAPSHOT
   - org.ystia.ansible.linux.ansible:3.0.0-SNAPSHOT
@@ -30,7 +30,7 @@ imports:
 
 repositories:
   fastconnect_nexus:
-    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/2.2.0
+    url: https://fastconnect.org/maven/service/local/repositories/opensource/content/alien4cloud/alien4cloud-dist/3.0.0-SNAPSHOT
     type: http
 
 topology_template:
@@ -244,7 +244,7 @@ topology_template:
             initiator: source
       artifacts:
         alien_dist:
-          file: alien4cloud-dist-2.2.0-dist.tar.gz
+          file: alien4cloud-dist-3.0.0-SNAPSHOT-dist.tar.gz
           type: tosca.artifacts.File
           repository: fastconnect_nexus
     YorcPlugin:

--- a/org/ystia/topologies/a4c_yorc_ha/types.yml
+++ b/org/ystia/topologies/a4c_yorc_ha/types.yml
@@ -2,7 +2,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.a4c_yorc_ha
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: ""
@@ -15,18 +15,18 @@ imports:
   - org.alien4cloud.alien4cloud.webapp:2.2.0
   - org.alien4cloud.java.jdk.linux:2.2.0
   - org.alien4cloud.alien4cloud.config.pub:2.2.0
-  - org.ystia.terraform.linux.terraform:2.3.0-SNAPSHOT
-  - org.ystia.yorc.alien4cloud:2.3.0-SNAPSHOT
-  - org.ystia.ansible.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.terraform.pub:2.3.0-SNAPSHOT
-  - org.ystia.yorc.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.ansible.pub:2.3.0-SNAPSHOT
-  - org.ystia.yorc.pub:2.3.0-SNAPSHOT
-  - org.ystia.nfs.pub:2.3.0-SNAPSHOT
-  - org.ystia.nfs.linux.ansible:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.yorc.alien4cloud_yorc_provider:2.3.0-SNAPSHOT
+  - org.ystia.terraform.linux.terraform:3.0.0-SNAPSHOT
+  - org.ystia.yorc.alien4cloud:3.0.0-SNAPSHOT
+  - org.ystia.ansible.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.terraform.pub:3.0.0-SNAPSHOT
+  - org.ystia.yorc.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.ansible.pub:3.0.0-SNAPSHOT
+  - org.ystia.yorc.pub:3.0.0-SNAPSHOT
+  - org.ystia.nfs.pub:3.0.0-SNAPSHOT
+  - org.ystia.nfs.linux.ansible:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.yorc.alien4cloud_yorc_provider:3.0.0-SNAPSHOT
 
 repositories:
   fastconnect_nexus:

--- a/org/ystia/topologies/cloudera-basic/types.yml
+++ b/org/ystia/topologies/cloudera-basic/types.yml
@@ -8,16 +8,16 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.cloudera-basic
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.cloudera.pub:2.3.0-SNAPSHOT
-  - org.ystia.cloudera.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.cloudera.pub:3.0.0-SNAPSHOT
+  - org.ystia.cloudera.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A topology template for Cloudera.

--- a/org/ystia/topologies/elk_basic/types.yml
+++ b/org/ystia/topologies/elk_basic/types.yml
@@ -8,23 +8,23 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.elk_basic
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.logstash.pub:2.3.0-SNAPSHOT
-  - org.ystia.logstash.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.logstash.pub:3.0.0-SNAPSHOT
+  - org.ystia.logstash.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A topology template to connect Logstash, Elasticsearch and Kibana

--- a/org/ystia/topologies/elk_broker/types.yml
+++ b/org/ystia/topologies/elk_broker/types.yml
@@ -8,24 +8,24 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.elk_broker
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.logstash.pub:2.3.0-SNAPSHOT
-  - org.ystia.logstash.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kafka.pub:2.3.0-SNAPSHOT
-  - org.ystia.kafka.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.logstash.pub:3.0.0-SNAPSHOT
+  - org.ystia.logstash.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kafka.pub:3.0.0-SNAPSHOT
+  - org.ystia.kafka.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A topology template to connect Kafka, Logstash, Elasticsearch and Kibana (Kafka as a broker)

--- a/org/ystia/topologies/elk_geonames/types.yml
+++ b/org/ystia/topologies/elk_geonames/types.yml
@@ -8,21 +8,21 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.elk_geonames
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.logstash.pub:2.3.0-SNAPSHOT
-  - org.ystia.logstash.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.logstash.pub:3.0.0-SNAPSHOT
+  - org.ystia.logstash.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A basic topology template for Logstash/Elasticsearch with GeoNames input

--- a/org/ystia/topologies/elk_ha/types.yml
+++ b/org/ystia/topologies/elk_ha/types.yml
@@ -14,7 +14,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0
+  - alien-extended-storage-types:3.0.0
 
   - org.ystia.common:3.0.0-SNAPSHOT
   - org.ystia.java.pub:3.0.0-SNAPSHOT

--- a/org/ystia/topologies/elk_ha/types.yml
+++ b/org/ystia/topologies/elk_ha/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.elk_ha
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
@@ -16,19 +16,19 @@ imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - alien-extended-storage-types:2.2.0
 
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.pub:2.3.0-SNAPSHOT
-  - org.ystia.elasticsearch.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kibana.pub:2.3.0-SNAPSHOT
-  - org.ystia.kibana.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.logstash.pub:2.3.0-SNAPSHOT
-  - org.ystia.logstash.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.kafka.pub:2.3.0-SNAPSHOT
-  - org.ystia.kafka.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.pub:3.0.0-SNAPSHOT
+  - org.ystia.elasticsearch.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kibana.pub:3.0.0-SNAPSHOT
+  - org.ystia.kibana.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.logstash.pub:3.0.0-SNAPSHOT
+  - org.ystia.logstash.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.kafka.pub:3.0.0-SNAPSHOT
+  - org.ystia.kafka.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A topology template to connect Kafka, Logstash, Elasticsearch and Kibana (Kafka as a broker), in High Avaibilty mode

--- a/org/ystia/topologies/flink/types.yml
+++ b/org/ystia/topologies/flink/types.yml
@@ -8,19 +8,19 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.flink
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.flink.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.consul.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.flink.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.flink.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.consul.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.flink.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A basic topology template with Flink

--- a/org/ystia/topologies/haproxy/types.yml
+++ b/org/ystia/topologies/haproxy/types.yml
@@ -8,15 +8,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.haproxy
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.haproxy.pub:2.3.0-SNAPSHOT
-  - org.ystia.haproxy.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.haproxy.pub:3.0.0-SNAPSHOT
+  - org.ystia.haproxy.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A basic topology template with HAProxyHTTP and HAProxyTCP

--- a/org/ystia/topologies/jupyter/types.yml
+++ b/org/ystia/topologies/jupyter/types.yml
@@ -13,7 +13,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0
+  - alien-extended-storage-types:3.0.0
   - org.ystia.common:3.0.0-SNAPSHOT
   - org.ystia.python.pub:3.0.0-SNAPSHOT
   - org.ystia.python.linux.bash:3.0.0-SNAPSHOT

--- a/org/ystia/topologies/jupyter/types.yml
+++ b/org/ystia/topologies/jupyter/types.yml
@@ -8,16 +8,16 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.jupyter
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - alien-extended-storage-types:2.2.0
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.python.pub:2.3.0-SNAPSHOT
-  - org.ystia.python.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.jupyter.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.python.pub:3.0.0-SNAPSHOT
+  - org.ystia.python.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.jupyter.linux.bash:3.0.0-SNAPSHOT
 
 
 topology_template:

--- a/org/ystia/topologies/mysql_single/types.yml
+++ b/org/ystia/topologies/mysql_single/types.yml
@@ -8,13 +8,13 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.mysql_single
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.mysql.pub:2.3.0-SNAPSHOT
-  - org.ystia.mysql.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.mysql.pub:3.0.0-SNAPSHOT
+  - org.ystia.mysql.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A basic topology template for MySQL as a Single Server node

--- a/org/ystia/topologies/rstudio/types.yml
+++ b/org/ystia/topologies/rstudio/types.yml
@@ -13,7 +13,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - alien-extended-storage-types:2.2.0
+  - alien-extended-storage-types:3.0.0
   - org.ystia.common:3.0.0-SNAPSHOT
   - org.ystia.java.pub:3.0.0-SNAPSHOT
   - org.ystia.java.linux.bash:3.0.0-SNAPSHOT

--- a/org/ystia/topologies/rstudio/types.yml
+++ b/org/ystia/topologies/rstudio/types.yml
@@ -8,16 +8,16 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.topologies.rstudio
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - alien-extended-storage-types:2.2.0
-  - org.ystia.common:2.3.0-SNAPSHOT
-  - org.ystia.java.pub:2.3.0-SNAPSHOT
-  - org.ystia.java.linux.bash:2.3.0-SNAPSHOT
-  - org.ystia.rstudio.linux.bash:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
+  - org.ystia.java.pub:3.0.0-SNAPSHOT
+  - org.ystia.java.linux.bash:3.0.0-SNAPSHOT
+  - org.ystia.rstudio.linux.bash:3.0.0-SNAPSHOT
 
 topology_template:
   description: A basic topology template with RStudio

--- a/org/ystia/topologies/slurm/types.yml
+++ b/org/ystia/topologies/slurm/types.yml
@@ -8,15 +8,15 @@ metadata:
 description: "Configure a Slurm cluster"
 
 imports:
-  - org.ystia.ntp.ansible:2.3.0-SNAPSHOT
-  - org.ystia.ntp.pub:2.3.0-SNAPSHOT
+  - org.ystia.ntp.ansible:3.0.0-SNAPSHOT
+  - org.ystia.ntp.pub:3.0.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.slurm.pub:2.3.0-SNAPSHOT
-  - org.ystia.munge.ansible:2.3.0-SNAPSHOT
-  - org.ystia.slurm.ansible:2.3.0-SNAPSHOT
-  - org.ystia.dns.resolvconf.ansible:2.3.0-SNAPSHOT
-  - org.ystia.dns.pub:2.3.0-SNAPSHOT
-  - org.ystia.dns.dnsmasq.ansible:2.3.0-SNAPSHOT
+  - org.ystia.slurm.pub:3.0.0-SNAPSHOT
+  - org.ystia.munge.ansible:3.0.0-SNAPSHOT
+  - org.ystia.slurm.ansible:3.0.0-SNAPSHOT
+  - org.ystia.dns.resolvconf.ansible:3.0.0-SNAPSHOT
+  - org.ystia.dns.pub:3.0.0-SNAPSHOT
+  - org.ystia.dns.dnsmasq.ansible:3.0.0-SNAPSHOT
   - yorc-types:1.1.0
 
 topology_template:

--- a/org/ystia/traefik/ansible-linux/types.yml
+++ b/org/ystia/traefik/ansible-linux/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.traefik.ansible-linux
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Traefik reverse proxy implementation using Ansible on Linux
@@ -16,7 +16,7 @@ description: Traefik reverse proxy implementation using Ansible on Linux
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.traefik.pub:2.3.0-SNAPSHOT
+  - org.ystia.traefik.pub:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.traefik.ansible-linux.nodes.Traefik:

--- a/org/ystia/traefik/pub/types.yml
+++ b/org/ystia/traefik/pub/types.yml
@@ -8,7 +8,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.traefik.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Public interface types for Traefik reverse proxy support.

--- a/org/ystia/xfs/linux/bash/types.yml
+++ b/org/ystia/xfs/linux/bash/types.yml
@@ -8,14 +8,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.xfs.linux.bash
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: Ystia
 
 description: Extended Storage Ystia Component
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.ystia.common:2.3.0-SNAPSHOT
+  - org.ystia.common:3.0.0-SNAPSHOT
 
 node_types:
   org.ystia.xfs.linux.bash.nodes.XFS:

--- a/org/ystia/yorc/alien4cloud-yorc-provider/types.yaml
+++ b/org/ystia/yorc/alien4cloud-yorc-provider/types.yaml
@@ -6,11 +6,11 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - org.alien4cloud.alien4cloud.pub:2.2.0
-  - org.alien4cloud.alien4cloud.config.pub:2.2.0
-  - org.alien4cloud.alien4cloud.config.location:2.2.0
-  - org.alien4cloud.alien4cloud.config.location_resources.on_demand:2.2.0
-  - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:2.2.0
+  - org.alien4cloud.alien4cloud.pub:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.pub:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location_resources.on_demand:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:3.0.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
   - org.ystia.yorc.pub:3.0.0-SNAPSHOT

--- a/org/ystia/yorc/alien4cloud-yorc-provider/types.yaml
+++ b/org/ystia/yorc/alien4cloud-yorc-provider/types.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.alien4cloud_yorc_provider
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: alien4cloud
 
 imports:
@@ -13,7 +13,7 @@ imports:
   - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:2.2.0
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.yorc.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.pub:3.0.0-SNAPSHOT
 
 node_types:
 

--- a/org/ystia/yorc/alien4cloud/types.yaml
+++ b/org/ystia/yorc/alien4cloud/types.yaml
@@ -2,7 +2,7 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.alien4cloud
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: alien4cloud
 
 imports:
@@ -13,7 +13,7 @@ imports:
   - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:2.2.0
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.yorc.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.pub:3.0.0-SNAPSHOT
 
 node_types:
 

--- a/org/ystia/yorc/alien4cloud/types.yaml
+++ b/org/ystia/yorc/alien4cloud/types.yaml
@@ -6,11 +6,11 @@ metadata:
   template_author: alien4cloud
 
 imports:
-  - org.alien4cloud.alien4cloud.pub:2.2.0
-  - org.alien4cloud.alien4cloud.config.pub:2.2.0
-  - org.alien4cloud.alien4cloud.config.location:2.2.0
-  - org.alien4cloud.alien4cloud.config.location_resources.on_demand:2.2.0
-  - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:2.2.0
+  - org.alien4cloud.alien4cloud.pub:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.pub:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location_resources.on_demand:3.0.0-SNAPSHOT
+  - org.alien4cloud.alien4cloud.config.location_resources.autoconfig:3.0.0-SNAPSHOT
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
   - org.ystia.yorc.pub:3.0.0-SNAPSHOT

--- a/org/ystia/yorc/yorc/docker/README.md
+++ b/org/ystia/yorc/yorc/docker/README.md
@@ -8,7 +8,7 @@ The deployment to Kubernetes can be done using Alien4Cloud and Yorc.
 
 ## About versions
 
-1. Used Alien version: 2.2.0 (docker-types:2.2.0)
+1. Used Alien version: 3.0.0 (docker-types:3.0.0)
 2. Deployed Yorc version: last available in jfrog (file: ystia-docker.jfrog.io/ystia/yorc)
 
 ## Usage

--- a/org/ystia/yorc/yorc/docker/types.yaml
+++ b/org/ystia/yorc/yorc/docker/types.yaml
@@ -22,7 +22,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - docker-types:2.2.0
+  - docker-types:3.0.0
 
 description: Yorc&Consul Docker Component
 

--- a/org/ystia/yorc/yorc/linux/ansible/types.yaml
+++ b/org/ystia/yorc/yorc/linux/ansible/types.yaml
@@ -18,14 +18,14 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.linux.ansible
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: yorc
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - yorc-types:1.1.0
-  - org.ystia.yorc.pub:2.3.0-SNAPSHOT
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.pub:3.0.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
 
 
 node_types:

--- a/org/ystia/yorc/yorc/pub/types.yaml
+++ b/org/ystia/yorc/yorc/pub/types.yaml
@@ -22,7 +22,7 @@ metadata:
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
-  - org.alien4cloud.vault.pub:2.2.0
+  - org.alien4cloud.vault.pub:3.0.0-SNAPSHOT
   - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
   - org.ystia.ansible.pub:3.0.0-SNAPSHOT
   - org.ystia.terraform.pub:3.0.0-SNAPSHOT

--- a/org/ystia/yorc/yorc/pub/types.yaml
+++ b/org/ystia/yorc/yorc/pub/types.yaml
@@ -17,15 +17,15 @@ tosca_definitions_version: alien_dsl_2_0_0
 
 metadata:
   template_name: org.ystia.yorc.pub
-  template_version: 2.3.0-SNAPSHOT
+  template_version: 3.0.0-SNAPSHOT
   template_author: yorc
 
 imports:
   - tosca-normative-types:1.0.0-ALIEN20
   - org.alien4cloud.vault.pub:2.2.0
-  - org.ystia.yorc.experimental.consul.pub:2.3.0-SNAPSHOT
-  - org.ystia.ansible.pub:2.3.0-SNAPSHOT
-  - org.ystia.terraform.pub:2.3.0-SNAPSHOT
+  - org.ystia.yorc.experimental.consul.pub:3.0.0-SNAPSHOT
+  - org.ystia.ansible.pub:3.0.0-SNAPSHOT
+  - org.ystia.terraform.pub:3.0.0-SNAPSHOT
 
 data_types:
   org.ystia.yorc.datatypes.ansible.inventory.Section:

--- a/versions.yaml
+++ b/versions.yaml
@@ -1,1 +1,1 @@
-forge_version: 2.3.0-SNAPSHOT
+forge_version: 3.0.0-SNAPSHOT


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

Switched to Alien 3.0 dependencies
Updated version to 3.0.0-SNAPSHOT

### Description for the changelog

* Ystia Forge components require now Alien4Cloud 3.0.0
