### PR TITLE
[Backport release/2.2] Added container property shm_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Add docker container property to set the shared memory size ([GH-129](https://github.com/ystia/forge/issues/129))
+
 ## 2.2.0 (April 17, 2020)
 
 ### NEW COMPONENTS

--- a/org/ystia/docker/containers/generic/playbooks/docker_container_tasks.yaml
+++ b/org/ystia/docker/containers/generic/playbooks/docker_container_tasks.yaml
@@ -40,6 +40,7 @@
     memory_reservation: "{{MEM_SHARE}}"
     published_ports: "{{DOCKER_PUB_PORT}}"
     restart_policy: "{{RESTART_POLICY}}"
+    shm_size: "{{SHM_SIZE}}"
     user: "{{ USER }}"
     volumes: "{{ DOCKER_VOLUMES }}"
     state: "{{ DOCKER_STATE }}"

--- a/org/ystia/docker/containers/generic/types.yml
+++ b/org/ystia/docker/containers/generic/types.yml
@@ -74,6 +74,14 @@ node_types:
         constraints:
           - valid_values: ["no", "on-failure", "always", "unless-stopped"]
         default: "no"
+      shm_size:
+        type: scalar-unit.size
+        description: |
+          Size of /dev/shm, shared memory used by the container.
+          If omitted, the system uses 64 MB.
+        constraints:
+          - greater_or_equal: 0 B
+        required: false
       user:
         type: string
         description: "Username or UID (format: <name|uid>[:<group|gid>])"
@@ -111,6 +119,7 @@ node_types:
           MEM_SHARE_LIMIT: { get_property: [SELF, mem_share_limit] }
           PUBLISHED_PORTS: { get_property: [SELF, published_ports] }
           RESTART_POLICY: { get_property: [SELF, restart_policy] }
+          SHM_SIZE: { get_property: [SELF, shm_size] }
           USER: { get_property: [SELF, user] }
           VOLUMES: { get_property: [SELF, volumes] }
           WORKDIR: { get_property: [SELF, workdir] }


### PR DESCRIPTION
# Pull Request description

This is a back-port of #130 

## Description of the change

Added a property to define the shared memory used by a container.
Can be needed for containers for which the system default shared memory size (64 MB) is not enough.
 
### What I did

Added a property `shm_size` to TOSCA component `ystia.docker.containers.docker.generic.nodes.GenericContainer`.
This property value is passed to the ansible playbook creating a docker container as a property of same name in the ansible docker_container module.

### How to verify it

Deploy an application using a GenericContainer with the property `shm_size`set to a value different from the system default 64 MB.

On the deployed environment, use the command `docker inspect <container id>` to verify that its property `ShmSize` has the expected value expressed in bytes

### Description for the changelog

Add docker container property to set the shared memory size ([GH-129](https://github.com/ystia/forge/issues/129))

## Applicable Issues

Fixes #129 
Back-Port of #130 

