### PR TITLE
Feature/ansible version update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### ENHANCEMENTS
 
+* Update Ansible to 2.10 ([GH-136](https://github.com/ystia/forge/issues/136))
 * Add docker container property to set the shared memory size ([GH-129](https://github.com/ystia/forge/issues/129))
 
 ### BUG FIXES

--- a/org/ystia/ansible/linux/ansible/playbooks/create.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/create.yml
@@ -22,9 +22,7 @@
   tasks:
 
     - name: Get python version
-      # This will be deprecated in Ansible 2.9 in favor of python_requirements_info but
-      # it is not yet available in Ansible 2.7.9
-      python_requirements_facts:
+      python_requirements_info:
       register: pri
       failed_when: "pri == None or pri.python_version == None or pri.python_version == ''"
 

--- a/org/ystia/ansible/linux/ansible/playbooks/create.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/create.yml
@@ -60,5 +60,6 @@
           - "ansible=={{ANSIBLE_VERSION}}"
           - "jmespath==0.9.4"
           - "netaddr==0.7.19"
+          - "paramiko"
         executable: "{{pip_cmd}}"
         extra_args: "{{ '--extra-index-url {}'.format(ANSIBLE_EXTRA_PACKAGE_REPOSITORY) if ANSIBLE_EXTRA_PACKAGE_REPOSITORY != ''  else ''}}"

--- a/org/ystia/dns/dnsmasq/ansible/playbooks/roles/jriguera.dnsmasq/tasks/install.yml
+++ b/org/ystia/dns/dnsmasq/ansible/playbooks/roles/jriguera.dnsmasq/tasks/install.yml
@@ -95,7 +95,7 @@
 
   - name: Reload systemd
     command: systemctl daemon-reload
-    when: __dnsmasq_systemd|changed
+    when: __dnsmasq_systemd is changed
 
   when: dnsmasq_init_system == 'systemd'
   tags: ["systemd", "init"]

--- a/org/ystia/experimental/consul/linux/ansible/playbooks/consul_configure.yaml
+++ b/org/ystia/experimental/consul/linux/ansible/playbooks/consul_configure.yaml
@@ -131,7 +131,7 @@
         country_name: "FR"
         organization_name: "Atos"
         common_name: "127.0.0.1"
-        subjectAltName: '{{ subjectAltName }},IP:127.0.0.1,DNS:localhost'
+        subjectAltName: "{{ subjectAltName }},IP:127.0.0.1,DNS:localhost"
       when: consul_secured
 
     - name: Install CA key
@@ -155,7 +155,4 @@
         ownca_privatekey_path: "{{ CONFIG_DIR }}/ca.key"
         ownca_privatekey_passphrase: "{{ CA_PASSPHRASE }}"
         provider: ownca
-        subjectAltName: '{{ subjectAltName }},IP:127.0.0.1,DNS:localhost'
-        extended_key_usage:
-          - serverAuth
       when: consul_secured

--- a/org/ystia/experimental/consul/linux/ansible/playbooks/consul_configure.yaml
+++ b/org/ystia/experimental/consul/linux/ansible/playbooks/consul_configure.yaml
@@ -34,7 +34,7 @@
       set_fact:
         consul_servers: "{{ consul_servers }} + [ '{{ hostvars[inventory_hostname][item] }}' ]"
       with_items: "{{ hostvars[inventory_hostname]  }}"
-      when: MODE == "server" and item | match(NODE+'_.*_IP_ADDRESS')
+      when: MODE == "server" and item is match(NODE+'_.*_IP_ADDRESS')
 
     - name: Check if CA provided
       set_fact:

--- a/org/ystia/experimental/consul/linux/ansible/playbooks/consul_connects_agent_to_server.yml
+++ b/org/ystia/experimental/consul/linux/ansible/playbooks/consul_connects_agent_to_server.yml
@@ -27,14 +27,14 @@
       set_fact: 
         consul_servers: "{{ consul_servers }} + [ '{{ hostvars[inventory_hostname][item] }}' ]"
       with_items: "{{ hostvars[inventory_hostname]  }}"
-      when: (item | match(TARGET_NODE+'_.*_SERVER_IP')) and
+      when: (item is match(TARGET_NODE+'_.*_SERVER_IP')) and
             (SERVER_IP_CAP is not defined or SERVER_IP_CAP is none or SERVER_IP_CAP == '' )
 
     - name: compute consul servers
       set_fact:
         consul_servers: "{{ consul_servers }} + [ '{{ hostvars[inventory_hostname][item] }}' ]"
       with_items: "{{ hostvars[inventory_hostname]  }}"
-      when: (item | match(TARGET_NODE+'_.*SERVER_IP_CAP')) and
+      when: (item is match(TARGET_NODE+'_.*SERVER_IP_CAP')) and
             (SERVER_IP_CAP is defined and SERVER_IP_CAP is not none and SERVER_IP_CAP != '' )
 
     - name: Install servers config for consul

--- a/org/ystia/experimental/consul/linux/ansible/playbooks/consul_connects_servers_wan.yaml
+++ b/org/ystia/experimental/consul/linux/ansible/playbooks/consul_connects_servers_wan.yaml
@@ -27,7 +27,7 @@
       set_fact: 
         consul_wan_servers: "{{ consul_wan_servers }} + [ '{{ hostvars[inventory_hostname][item] }}' ]"
       with_items: "{{ hostvars[inventory_hostname]  }}"
-      when: item | match(TARGET_NODE+'_.*_SERVER_WAN_IP')
+      when: item is match(TARGET_NODE+'_.*_SERVER_WAN_IP')
 
     - name: Install servers config for consul
       template: 

--- a/org/ystia/experimental/consul/linux/ansible/playbooks/consul_install.yaml
+++ b/org/ystia/experimental/consul/linux/ansible/playbooks/consul_install.yaml
@@ -61,9 +61,7 @@
       when: INSTALL_DNSMASQ == "true"
 
     - name: Get python version
-      # This will be deprecated in Ansible 2.9 in favor of python_requirements_info but
-      # it is not yet available in Ansible 2.7.9
-      python_requirements_facts:
+      python_requirements_info:
       register: pri
       failed_when: "pri == None or pri.python_version == None or pri.python_version == ''"
 
@@ -121,7 +119,7 @@
       user:
         name: "{{ yorc_prov_user }}"
         append: yes
-        group: consul
+        groups: consul
 
     - name: create Consul user
       user:

--- a/org/ystia/experimental/consul/linux/ansible/playbooks/roles/jriguera.dnsmasq/tasks/install.yml
+++ b/org/ystia/experimental/consul/linux/ansible/playbooks/roles/jriguera.dnsmasq/tasks/install.yml
@@ -95,7 +95,7 @@
 
   - name: Reload systemd
     command: systemctl daemon-reload
-    when: __dnsmasq_systemd|changed
+    when: __dnsmasq_systemd is changed
 
   when: dnsmasq_init_system == 'systemd'
   tags: ["systemd", "init"]

--- a/org/ystia/mongodb/linux/ansible/playbooks/roles/undergreen.ansible-role-mongodb/tasks/configure.yml
+++ b/org/ystia/mongodb/linux/ansible/playbooks/roles/undergreen.ansible-role-mongodb/tasks/configure.yml
@@ -67,7 +67,7 @@
 
 - name: mongodb restart
   service: name={{ mongodb_daemon_name }} state=restarted
-  when: config_result|changed and mongodb_manage_service
+  when: config_result is changed and mongodb_manage_service
 
 - name: Ensure service is started
   service: name={{ mongodb_daemon_name }} state=started

--- a/org/ystia/slurm/ansible/playbooks/install-RedHat.yml
+++ b/org/ystia/slurm/ansible/playbooks/install-RedHat.yml
@@ -14,17 +14,18 @@
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   
 - name: Install rpmbuild and required tools to build Slurm packages
-  yum: 
-    name: "{{ item }}"
-  with_items:
-    - rpm-build
-    - gcc
-    - perl-devel
-    - readline-devel
-    - openssl-devel
-    - munge-devel
-    - munge-libs
-    - pam-devel
+  yum:
+    name:
+      - rpm-build
+      - gcc
+      - perl-devel
+      - readline-devel
+      - openssl-devel
+      - munge-devel
+      - munge-libs
+      - pam-devel
+    state: present
+    update_cache: yes
 
 - name: Download Slurm archive
   get_url:
@@ -61,8 +62,9 @@
 
 - name: Install Slurm
   yum: 
-    name: "{{item}}"
-  with_items: "{{slurm_rpms_paths}}"
+    name: "{{slurm_rpms_paths}}"
+    state: present
+    update_cache: yes
 
 - name: Remove Slurm installation artifacts
   file:

--- a/org/ystia/ssl/ansible-ssl-certificates/playbooks/configure.yml
+++ b/org/ystia/ssl/ansible-ssl-certificates/playbooks/configure.yml
@@ -95,7 +95,6 @@
         ownca_privatekey_path: "{{KEY_PATH}}/{{NODE}}-ca.key"
         ownca_privatekey_passphrase: "{{ CA_PASSPHRASE }}"
         provider: ownca
-        subjectAltName: "{{ subjectAltName }}"
 
     # Now we do not need it anymore so lets remove it 
     - name: Delete CA Key

--- a/org/ystia/terraform/linux/ansible/playbooks/create.yml
+++ b/org/ystia/terraform/linux/ansible/playbooks/create.yml
@@ -22,22 +22,20 @@
   tasks:
     - name: RedHat - install prerequisites
       yum:
-        name: "{{item}}"
+        name:
+          - zip
+          - unzip
         state: present
         update_cache: yes
-      with_items:
-      - zip
-      - unzip
       when: ansible_os_family == 'RedHat'
 
     - name: Debian - install prerequisites
       apt:
-        name: "{{item}}"
+        name:
+          - zip
+          - unzip
         state: present
         update_cache: yes
-      with_items:
-      - zip
-      - unzip
       when: ansible_os_family == 'Debian'
 
     - name: Download Terraform binary

--- a/org/ystia/yorc/alien4cloud-yorc-provider/playbook/connect_yorc.yml
+++ b/org/ystia/yorc/alien4cloud-yorc-provider/playbook/connect_yorc.yml
@@ -54,6 +54,9 @@
     - name: Generate an OpenSSL private key for the plugin
       openssl_privatekey:
         path: "{{ file_dir }}/yorc_client.key"
+        # Using pyopenssl here or Alien4Cloud cannot deal with the
+        # generated certificate
+        select_crypto_backend: pyopenssl
       when:  ca_pem != ''
 
     - name: Generate an OpenSSL CSR for the plugin

--- a/org/ystia/yorc/alien4cloud-yorc-provider/playbook/create_orchestrator.yml
+++ b/org/ystia/yorc/alien4cloud-yorc-provider/playbook/create_orchestrator.yml
@@ -95,7 +95,8 @@
         method: POST
         return_content: yes
         validate_certs: no
-        HEADER_cookie: "{{ session_id }}"
+        headers:
+          Cookie: "{{ session_id }}"
         body:
           name: "{{ orchestrator_name }}"
           pluginId: "{{ pluginId }}"
@@ -140,8 +141,9 @@
         method: PUT
         return_content: yes
         validate_certs: no
-        HEADER_cookie: "{{ session_id }}"
-        HEADER_Content-Type: "application/json"
+        headers:
+          Cookie: "{{ session_id }}"
+          Content-Type: "application/json"
         body: "{{ orchestratorConfiguration }}"
         body_format: json
         status_code: 200
@@ -153,8 +155,9 @@
         method: PUT
         return_content: yes
         validate_certs: no
-        HEADER_cookie: "{{ session_id }}"
-        HEADER_Content-Type: "application/json"
+        headers:
+          Cookie: "{{ session_id }}"
+          Content-Type: "application/json"
         body:
           deploymentNamePattern: "('{{ discriminator }}-' + application.name + '-' + environment.name).replaceAll('[^\\w\\-_]', '_')"
         body_format: json
@@ -166,8 +169,9 @@
         url: "{{ alien_url }}/rest/latest/orchestrators/{{ orchestratorId }}/instance"
         method: POST
         validate_certs: no
-        HEADER_cookie: "{{ session_id }}"
-        HEADER_Content-Type: "application/json"
+        headers:
+          Cookie: "{{ session_id }}"
+          Content-Type: "application/json"
 
     - name: Wait for orchestrator to be started
       uri:
@@ -175,8 +179,9 @@
         method: GET
         validate_certs: no
         return_content: yes
-        HEADER_cookie: "{{ session_id }}"
-        HEADER_Content-Type: "application/json"
+        headers:
+          Cookie: "{{ session_id }}"
+          Content-Type: "application/json"
         status_code: 200
       register: result
       until: result.json.data.state == "CONNECTED"

--- a/org/ystia/yorc/alien4cloud/playbook/create_orchestrator.yml
+++ b/org/ystia/yorc/alien4cloud/playbook/create_orchestrator.yml
@@ -95,7 +95,8 @@
         method: POST
         return_content: yes
         validate_certs: no
-        HEADER_cookie: "{{ session_id }}"
+        headers:
+          Cookie: "{{ session_id }}"
         body:
           name: "{{ orchestrator_name }}"
           pluginId: "{{ pluginId }}"
@@ -140,8 +141,9 @@
         method: PUT
         return_content: yes
         validate_certs: no
-        HEADER_cookie: "{{ session_id }}"
-        HEADER_Content-Type: "application/json"
+        headers:
+          Cookie: "{{ session_id }}"
+          Content-Type: "application/json"
         body: "{{ orchestratorConfiguration }}"
         body_format: json
         status_code: 200
@@ -153,8 +155,9 @@
         method: PUT
         return_content: yes
         validate_certs: no
-        HEADER_cookie: "{{ session_id }}"
-        HEADER_Content-Type: "application/json"
+        headers:
+          Cookie: "{{ session_id }}"
+          Content-Type: "application/json"
         body:
           deploymentNamePattern: "('{{ discriminator }}-' + application.name + '-' + environment.name).replaceAll('[^\\w\\-_]', '_')"
         body_format: json
@@ -166,8 +169,9 @@
         url: "{{ alien_url }}/rest/latest/orchestrators/{{ orchestratorId }}/instance"
         method: POST
         validate_certs: no
-        HEADER_cookie: "{{ session_id }}"
-        HEADER_Content-Type: "application/json"
+        headers:
+          Cookie: "{{ session_id }}"
+          Content-Type: "application/json"
 
     - name: Wait for orchestrator to be started
       uri:
@@ -175,8 +179,9 @@
         method: GET
         validate_certs: no
         return_content: yes
-        HEADER_cookie: "{{ session_id }}"
-        HEADER_Content-Type: "application/json"
+        headers:
+          Cookie: "{{ session_id }}"
+          Content-Type: "application/json"
         status_code: 200
       register: result
       until: result.json.data.state == "CONNECTED"

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure.yml
@@ -114,7 +114,7 @@
         path: "{{ CONFIG_DIR }}/yorc_server.csr"
         privatekey_path: "{{ CONFIG_DIR }}/yorc_server.key"
         common_name: "yorcServer"
-        subjectAltName: '{{ subjectAltName }}'
+        subjectAltName: "{{ subjectAltName }}"
       when: REST_API_PROTOCOL == "https"
 
     - name: Generate a OpenSSL certificate for the server
@@ -125,9 +125,6 @@
         ownca_privatekey_path: "{{ CONFIG_DIR }}/yorc_ca.key"
         ownca_privatekey_passphrase: "{{ CA_PASSPHRASE }}"
         provider: ownca
-        subjectAltName: '{{ subjectAltName }}'
-        extended_key_usage:
-          - serverAuth
       when: REST_API_PROTOCOL == "https"
 
     - name: Generate an OpenSSL private key for the client


### PR DESCRIPTION
# Pull Request description

## Description of the change

Following Yorc use of Ansible 2.10 to address issue ([GH-648](https://github.com/ystia/yorc/issues/648)),
updated playbooks to remove deprecation warnings and fix what was already deprecated in previous versions and has been removed in Ansible 2.10

### What I did

`org/ystia/ansible/linux/ansible/playbooks/create.yml`
`python_requirements_facts` is now `python_requirements_info`.
paramiko was removed from Ansible requirements.txt and has now to be installed separately.

`org/ystia/dns/dnsmasq/ansible/playbooks/roles/jriguera.dnsmasq/tasks/install.yml`
 Not anymore able to use Jinja tests as filters like `changed` or `match`
=> replace: `when: value|changed` by `when:  value is changed`

`org/ystia/experimental/consul/linux/ansible/playbooks/consul_configure.yaml`
Jinja test `match` cannot be used anymore as filter.
Parameter `subjectAltName` must be used in `opensl_csr`, not in `openssl_certificate`

`org/ystia/experimental/consul/linux/ansible/playbooks/consul_connects_agent_to_server.yml`
`org/ystia/experimental/consul/linux/ansible/playbooks/consul_connects_servers_wan.yaml`
Jinja test `match` cannot be used anymore as filter.

`org/ystia/experimental/consul/linux/ansible/playbooks/consul_install.yaml`
`python_requirements_facts` is now `python_requirements_info`.
Fixed a warning asking to define groups for a user.

`org/ystia/experimental/consul/linux/ansible/playbooks/roles/jriguera.dnsmasq/tasks/install.yml`
`org/mongodb/linux/ansible/playbooks/roles/undergreen.ansible-role-mongodb/tasks/configure.yml`
Jinja test `changed` cannot be used anymore as filter.

`org/ystia/slurm/ansible/playbooks/install-RedHat.yml`
Invoking "yum" or apt only once while using a loop via squash_actions is deprecated

`org/ystia/ssl/ansible-ssl-certificates/playbooks/configure.yml`
Parameter `subjectAltName` must be used in `opensl_csr`, not in `openssl_certificate`

`org/ystia/terraform/linux/ansible/playbooks/create.yml`
Invoking "yum" or apt only once while using a loop via squash_actions is deprecated

`org/ystia/yorc/alien4cloud-yorc-provider/playbook/connect_yorc.yml`
Using here a dpeprecated feature relying on pyopenssl instead of cryptography, otherwise certficates generated were causing exceptions like this one:

```
      org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'yorcOrchestrator': Unsatisfied dependency expressed through field 'templateManager'; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'templateManager': Invocation of init method failed; nested exception is java.lang.IllegalArgumentException: unknown object in getInstance: org.bouncycastle.asn1.DEROctetString
              at org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor$AutowiredFieldElement.inject(AutowiredAnnotationBeanPostProcessor.java:588)
...
      Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'templateManager': Invocation of init method failed; nested exception is java.lang.IllegalArgumentException: unknown object in getInstance: org.bouncycastle.asn1.DEROctetString
              at org.springframework.beans.factory.annotation.InitDestroyAnnotationBeanPostProcessor.postProcessBeforeInitialization(InitDestroyAnnotationBeanPostProcessor.java:137)
...
      Caused by: java.lang.IllegalArgumentException: unknown object in getInstance: org.bouncycastle.asn1.DEROctetString
              at org.bouncycastle.asn1.ASN1Sequence.getInstance(Unknown Source)
              at org.bouncycastle.asn1.pkcs.PrivateKeyInfo.getInstance(Unknown Source)
              at alien4cloud.paas.yorc.context.rest.TemplateManager.createKeystore(TemplateManager.java:208)
              at alien4cloud.paas.yorc.context.rest.TemplateManager.configure(TemplateManager.java:105)
```

`org/ystia/yorc/alien4cloud-yorc-provider/playbook/create_orchestrator.yml`
`org/ystia/yorc/alien4cloud/playbook/create_orchestrator.yml`
Ansible uri parameter HEADER_* is removed
=> replace `HEADER_cookie` and `HEADER_Content-Type` by:
```yaml
    headers:
      Cookie: xxx
      Content-Type: yyy
```

`org/ystia/yorc/yorc/linux/ansible/playbooks/configure.yml`
Parameter `subjectAltName` must be used in `opensl_csr`, not in `openssl_certificate`


### How to verify it

Changes are incorporated in yorc toca_types.zip in pull request https://github.com/ystia/yorc/pull/686
and can be used performing a bootstrap of yorc.

### Description for the changelog

Update Ansible to 2.10 ([GH-136](https://github.com/ystia/forge/issues/136))

## Applicable Issues

Fixes #136 
