### PR TITLE
Bugfix/gh 138 ansible upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### BUG FIXES
 
+* Upgrade of ansible to 2.10.0 fails ([GH-138](https://github.com/ystia/forge/issues/138))
 * Installation of Consul and Ansible fails on recent Centos for GCP images ([GH-131](https://github.com/ystia/forge/issues/131))
 
 ## 2.2.0 (April 17, 2020)

--- a/org/ystia/ansible/linux/ansible/playbooks/create.yml
+++ b/org/ystia/ansible/linux/ansible/playbooks/create.yml
@@ -54,6 +54,24 @@
         state: latest
         executable: "{{pip_cmd}}"
 
+    - name: uninstall Ansible older version that cannot be upgraded
+      pip:
+        name:
+          - "ansible<2.10.0"
+        state: absent
+
+    - name: check if ansible-playbook is missing
+      shell: ansible-playbook -h >/dev/null 2>&1
+      register: ansible_playbook_cmd_exists
+      ignore_errors: yes
+
+    - name: Remove ansible-base if ansible-playbook does not exist, can happen after a downgrade
+      pip:
+        name:
+          - "ansible-base>=2.10.0"
+        state: absent
+      when: ansible_playbook_cmd_exists.rc != 0
+
     - name: install Ansible using Pip
       pip:
         name:

--- a/org/ystia/ansible/pub/types.yaml
+++ b/org/ystia/ansible/pub/types.yaml
@@ -33,7 +33,7 @@ node_types:
       component_version:
         type: version
         required: true
-        default: 2.7.9
+        default: 2.10.0
       extra_package_repository_url:
         description: "URL of package indexes where to find the ansible package, instead of the default Python Package repository"
         type: string


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

pip can't upgrade ansible to version 2.10.0, the upgrade fails.
As described at https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.10.html :
```
Due to a limitation in pip, you cannot pip install --upgrade from ansible-2.9 or earlier to ansible-2.10 or higher. Instead, you must explicitly use pip uninstall ansible before pip installing the new version. If you attempt to upgrade Ansible with pip without first uninstalling, the installer warns you to uninstall first.
```

The forge AnsibleRuntime component should take care of this.

Also after a downgrade from ansible 2.10.0, ansible-base is still there.
If there is the need to upgrade again to 2.10.0, we should first uninstall the old ansible version, this will remove the command ansible-playbook.
But the install of ansible 2.10.0 won't install ansible-base seeing it is already installed, and finally the ansible-playbook command will be missing.
So in this case we should take care of uninstalling ansible-base before installing ansible, to ensure ansible-base is correctly installed,
else we will end up in a setup where the command ansible-playbook is missing 

### How to verify it

Can be tested using Yorc bootstrap integrating these changes in pull request https://github.com/ystia/yorc/pull/696
as described in the tests section of this pull request

### Description for the changelog

Upgrade of ansible to 2.10.0 fails ([GH-138](https://github.com/ystia/forge/issues/138))

## Applicable Issues

Closes #138
