### PR TITLE
Bugfix/gh 141 pip python2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### BUG FIXES
 
+* Components installing and using the latest pip version fail on systems using python 2.7 ([GH-141](https://github.com/ystia/forge/issues/141))
 * Upgrade of ansible to 2.10.0 fails ([GH-138](https://github.com/ystia/forge/issues/138))
 * Installation of Consul and Ansible fails on recent Centos for GCP images ([GH-131](https://github.com/ystia/forge/issues/131))
 

--- a/org/ystia/docker/containers/generic/playbooks/create.yaml
+++ b/org/ystia/docker/containers/generic/playbooks/create.yaml
@@ -9,10 +9,22 @@
   hosts: all
   become: true
   tasks:
+  - name: Get python version
+    python_requirements_info:
+    register: pri
+    failed_when: pri == None or pri.python_version == None or pri.python_version == ''
+  - name: Get python major version
+    set_fact:
+      python_major_version: "{{pri.python_version | replace('\n', '') | regex_replace('^(\\d+).*', '\\1') }}"
+  - name: Install pip version compatible with python 2
+    easy_install:
+      name: pip<21.0
+    when: python_major_version == "2"
   - name: Install pip
     easy_install:
       name: pip
       state: latest  
+    when: python_major_version != "2"
 
   - name: Install 'virtualenv' package
     pip:

--- a/org/ystia/samples/apache-log-generator/linux/ansible/apache-log-generator_install.yaml
+++ b/org/ystia/samples/apache-log-generator/linux/ansible/apache-log-generator_install.yaml
@@ -19,10 +19,22 @@
         - requirements.txt
         - apache-fake-log-gen.py
 
-    - name: Ensure pip is installed
-      easy_install:
-        name: pip
-        state: latest
+  - name: Get python version
+    python_requirements_info:
+    register: pri
+    failed_when: pri == None or pri.python_version == None or pri.python_version == ''
+  - name: Get python major version
+    set_fact:
+      python_major_version: "{{pri.python_version | replace('\n', '') | regex_replace('^(\\d+).*', '\\1') }}"
+  - name: Install pip version compatible with python 2
+    easy_install:
+      name: pip<21.0
+    when: python_major_version == "2"
+  - name: Install pip
+    easy_install:
+      name: pip
+      state: latest
+    when: python_major_version != "2"
 
     - name: Install Apache log Generator python requirements
       pip:

--- a/org/ystia/ssl/ansible-ssl-certificates/playbooks/create.yml
+++ b/org/ystia/ssl/ansible-ssl-certificates/playbooks/create.yml
@@ -19,10 +19,22 @@
   strategy: free
   become: true
   tasks:
+  - name: Get python version
+    python_requirements_info:
+    register: pri
+    failed_when: pri == None or pri.python_version == None or pri.python_version == ''
+  - name: Get python major version
+    set_fact:
+      python_major_version: "{{pri.python_version | replace('\n', '') | regex_replace('^(\\d+).*', '\\1') }}"
+  - name: Install pip version compatible with python 2
+    easy_install:
+      name: pip<21.0
+    when: python_major_version == "2"
   - name: Install pip
     easy_install:
       name: pip
       state: latest  
+    when: python_major_version != "2"
 
   - name: Install python packages
     pip:


### PR DESCRIPTION
# Pull Request description

## Description of the change

### What I did

As the latest pip version does not work with python 2.x,
updated playbooks installing pip to get the python version installed on the target and install a pip version < 21.0 on setups using python 2.x

### How to verify it

Deploy a toplogy template creating a CentOS 7 compute instance hosting  a docker component from this forge, hosting a docker container component from this pull request. Check the container could be created and started.

### Description for the changelog

Components installing and using the latest pip version fail on systems using python 2.7 ([GH-141](https://github.com/ystia/forge/issues/141))

## Applicable Issues

Closes #141
