### PR TITLE
conlocationsfig.yorc.yaml should be locations.yorc.yaml

### DIFF
--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_aws.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure_aws.yml
@@ -94,7 +94,7 @@
 
     - name: Set AWS secret key from vault
       replace:
-        path: "{{ CONFIG_DIR }}/conlocationsfig.yorc.yaml"
+        path: "{{ CONFIG_DIR }}/locations.yorc.yaml"
         regexp: 'SECRET_KEY_YORC_SUBSTITUTION'
         replace: "'{{ '{{' }} secret \"/secret/yorc/{{ LOCATION_NAME }}\" \"data=secret_key\" | print {{ '}}' }}'"
       when: USE_VAULT == "true"


### PR DESCRIPTION
Signed-off-by: Tim Beermann <beermann@osism.tech>

# Pull Request description

File name was not properly set.

## Description of the change

changed filename

### What I did

Tried to bootstrap yorc in AWS.

### How I did it

yorc bootstrap --values aws.yaml

### How to verify it

try to deploy in aws with these values:
```yaml
ansible:
  version: 2.10.0
  extra_package_repository_url: ""
  host_operations_allowed: false
alien4cloud:
  download_url: https://www.portaildulibre.fr/nexus/repository/opensource-releases/alien4cloud/alien4cloud-premium-dist/3.0.0-M8/alien4cloud-premium-dist-3.0.0-M8-dist.tar.gz
  port: 8088
  protocol: https
  user: admin
  password: admin
  extra_env: ""
yorcplugin:
  download_url: ""
consul:
  download_url: https://releases.hashicorp.com/consul/1.2.3/consul_1.2.3_linux_amd64.zip
  port: 8543
  tls_enabled: true
  tls_for_checks_enabled: true
  encrypt_key: foobar
terraform:
  download_url: https://releases.hashicorp.com/terraform/0.11.8/terraform_0.11.8_linux_amd64.zip
  plugins_download_urls:
  - https://releases.hashicorp.com/terraform-provider-google/1.18.0/terraform-provider-google_1.18.0_linux_amd64.zip
  - https://releases.hashicorp.com/terraform-provider-openstack/1.32.0/terraform-provider-openstack_1.32.0_linux_amd64.zip
  - https://releases.hashicorp.com/terraform-provider-aws/1.36.0/terraform-provider-aws_1.36.0_linux_amd64.zip
  - https://releases.hashicorp.com/terraform-provider-null/1.0.0/terraform-provider-null_1.0.0_linux_amd64.zip
  - https://releases.hashicorp.com/terraform-provider-consul/2.1.0/terraform-provider-consul_2.1.0_linux_amd64.zip
yorc:
  download_url: https://github.com/ystia/yorc/releases/download/v4.1.2/yorc-4.1.2.tgz
  port: 8800
  protocol: https
  private_key_content: |
    -----BEGIN OPENSSH PRIVATE KEY-----
    foobar
    -----END OPENSSH PRIVATE KEY-----
  private_key_file: /home/ubuntu/work/bootstrapResources/yorc.pem
  ca_pem: |
    -----BEGIN CERTIFICATE-----
    foobar
    -----END CERTIFICATE-----
  ca_pem_file: /home/ubuntu/work/bootstrapResources/ca.pem
  ca_key: |
    -----BEGIN RSA PRIVATE KEY-----
    Proc-Type: 4,ENCRYPTED
    DEK-Info: AES-256-CBC,213C8F603B1FCA3702453080E7EDEF2F
    foobar
    -----END RSA PRIVATE KEY-----
  ca_key_file: /home/ubuntu/work/bootstrapResources/ca-key.pem
  ca_passphrase: yorc
  data_dir: /var/yorc
  workers_number: 30
  resources_prefix: yorc-
locations:
- name: awseucentral1
  type: aws
  properties:
    access_key: foo
    region: eu-central-1
    secret_key: bar
compute:
  delete_volume_on_termination: true
  image_id: ami-05f7491af5eef733a
  instance_type: t3a.small
  key_name: yorc
  security_groups: all
credentials:
  user: ubuntu
  keys:
    "0": /home/ubuntu/work/bootstrapResources/yorc.pem
address:
  ip_version: 4
jdk:
  download_url: https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&os=linux&arch=x64&release=jdk8u212-b03&type=jdk
  version: 1.8.0-212-b03
location:
  type: aws
  name: awseucentral1
  resourcesfile: resources/ondemand_resources_aws.yaml
  properties:
    access_key: foo
    region: eu-central-1
    secret_key: bar
hosts: []
vault:
  download_url: https://releases.hashicorp.com/vault/1.0.3/vault_1.0.3_linux_amd64.zip
  port: 8200
insecure: false
```

### Description for the changelog

none

## Applicable Issues

none