### PR TITLE
Docker installation requires apt-transport-https to work properly on Debian based systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### BUG FIXES
 
+* Docker installation requires apt-transport-https to work properly on Debian based systems ([GH-147](https://github.com/ystia/forge/issues/147))
 * [Yorc] Error in AWS location configuration ([GH-145](https://github.com/ystia/forge/issues/145)) | Thanks to [@tibeer](https://github.com/tibeer) for this contribution
 
 ## 3.0.0-milestone.1 (April 25, 2021)

--- a/org/ystia/docker/ansible/playbooks/create.yaml
+++ b/org/ystia/docker/ansible/playbooks/create.yaml
@@ -28,9 +28,10 @@
       gpgcheck: yes
     when: ansible_os_family == 'RedHat'
 
-  - name: Ensure the APT package cache is updated
+  - name: Ensure apt-transport-https and that the APT package cache is updated
     apt:
       update_cache: yes
+      name: apt-transport-https
       cache_valid_time: 0
     when: ansible_os_family == 'Debian'
 


### PR DESCRIPTION
Signed-off-by: Tim Beermann <beermann@osism.tech>

# Pull Request description

1. Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
2. Please read our contribution guidelines
3. PR with a decent set of unit tests have more chance to be reviewed and merged quickly

## Description of the change

### What I did

### How I did it

### How to verify it

### Description for the changelog

Docker installation requires apt-transport-https to work properly on Debian based systems ([GH-147](https://github.com/ystia/forge/issues/147))

## Applicable Issues

Closes #147 
