### PR TITLE
Added host name in yorc certificate subject alternate name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+### ENHANCEMENTS
+
+* Add missing hostname in yorc certificate Subject Alternative Name ([GH-151](https://github.com/ystia/forge/issues/151))
+
 ### BUG FIXES
 
 * Docker installation requires apt-transport-https to work properly on Debian based systems ([GH-147](https://github.com/ystia/forge/issues/147))

--- a/org/ystia/yorc/yorc/linux/ansible/playbooks/configure.yml
+++ b/org/ystia/yorc/yorc/linux/ansible/playbooks/configure.yml
@@ -101,7 +101,7 @@
 
     - name: Get Host private IP address and DNS hostname for which TLS connections are accepted
       set_fact:
-        subjectAltName: "IP:{{ IP_ADDRESS }},IP:127.0.0.1,DNS:localhost,DNS:yorc.service.consul"
+        subjectAltName: "IP:{{ IP_ADDRESS }},IP:127.0.0.1,DNS:localhost,DNS:yorc.service.consul,DNS:{{ server_id }}"
       when: REST_API_PROTOCOL == "https"
 
     - name: Add Host public IP address to subjectAltName


### PR DESCRIPTION
# Pull Request description

Added the server id (HOSTNAME value) in Yorc certificate subject alternate name, as this is needed with consul 1.11.3 to check yorc service health.

Tested by doing a bootstrap using consul 1.11.3 in pull request https://github.com/ystia/yorc/pull/784

Closes #151 